### PR TITLE
Adjust CMake for building Cutter plugin for windows as dll.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH True)
 
 project(r2ghidra)
 
-set(RADARE2_INSTALL_PLUGDIR "share/radare2/plugins" CACHE PATH "Directory to install radare2 plugin into")
-set(CUTTER_INSTALL_PLUGDIR "share/RadareOrg/Cutter/plugins/native" CACHE PATH "Directory to install Cutter plugin into")
+set(RADARE2_INSTALL_PLUGDIR "share/radare2/plugins" CACHE STRING "Directory to install radare2 plugin into")
+set(CUTTER_INSTALL_PLUGDIR "share/RadareOrg/Cutter/plugins/native" CACHE STRING "Directory to install Cutter plugin into")
 
 set(CUTTER_SOURCE_DIR CUTTER_SOURCE_DIR-NOTFOUND CACHE STRING "Root directory of Cutter source")
 
@@ -58,10 +58,6 @@ endif()
 
 find_package(Radare2 REQUIRED)
 
-if(BUILD_CUTTER_PLUGIN)
-	add_subdirectory(cutter-plugin)
-endif()
-
 add_library(core_ghidra SHARED ${CORE_SOURCE})
 target_link_libraries(core_ghidra ghidra_decompiler_base ghidra_libdecomp ghidra_decompiler_sleigh)
 target_link_libraries(core_ghidra pugixml)
@@ -69,6 +65,11 @@ target_link_libraries(core_ghidra Radare2::libr)
 set_target_properties(core_ghidra PROPERTIES
 		OUTPUT_NAME core_ghidra
 		PREFIX "")
+
+
+if(BUILD_CUTTER_PLUGIN)
+	add_subdirectory(cutter-plugin)
+endif()
 
 if(BUILD_SLEIGH_PLUGIN)
 add_library(asm_ghidra SHARED ${ASM_SOURCE})

--- a/cmake/FindCutter.cmake
+++ b/cmake/FindCutter.cmake
@@ -1,6 +1,17 @@
 # requires CUTTER_SOURCE_DIR
 # sets CUTTER_INCLUDE_DIRS and Cutter::Cutter
 
+
+set(_module Cutter)
+
+
+# Prefer CutterConfig.cmake from Cutter installation if available.
+# FindCutter.cmake can be fully removed once all Cutter release packages include CutterConfig.
+find_package(${_module} CONFIG QUIET)
+if(${_module}_FOUND)
+	return()
+endif()
+
 if(CUTTER_SOURCE_DIR)
 	find_path(Cutter_SOURCE_ROOT
 			NAMES core/Cutter.h
@@ -21,6 +32,6 @@ Could not find Cutter headers. Make sure CUTTER_SOURCE_DIR is set to the root of
 
 if(Cutter_FOUND)
 	set(CUTTER_INCLUDE_DIRS "${Cutter_SOURCE_ROOT}" "${Cutter_SOURCE_ROOT}/common" "${Cutter_SOURCE_ROOT}/core")
-	add_library(Cutter::Cutter INTERFACE IMPORTED GLOBAL)
-	target_include_directories(Cutter::Cutter INTERFACE ${CUTTER_INCLUDE_DIRS})
+	add_library(${_module}::Cutter INTERFACE IMPORTED GLOBAL)
+	target_include_directories(${_module}::Cutter INTERFACE ${CUTTER_INCLUDE_DIRS})
 endif()

--- a/cutter-plugin/CMakeLists.txt
+++ b/cutter-plugin/CMakeLists.txt
@@ -17,13 +17,10 @@ target_link_libraries(r2ghidra_cutter Radare2::libr)
 
 find_package(Cutter REQUIRED)
 target_link_libraries(r2ghidra_cutter Cutter::Cutter)
+target_link_libraries(r2ghidra_cutter core_ghidra)
 
 if(APPLE)
 	target_link_options(r2ghidra_cutter PRIVATE -undefined dynamic_lookup)
-endif()
-
-if(WIN32)
-	target_link_options(r2ghidra_cutter PRIVATE -FORCE:UNRESOLVED)
 endif()
 
 install(TARGETS r2ghidra_cutter DESTINATION "${CUTTER_INSTALL_PLUGDIR}")


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Various changes to help with building Cutter plugin as dll on windows instead of current approach of static linking and relying on delayed symbol lookup at runtime.

* Change RADARE2_INSTALL_PLUGDIR and CUTTER_INSTALL_PLUGDIR as STRING instead of PATH so that you use paths relative to CMAKE_INSTALL_PREFIX. The cmake install commands where those variables are used handle relative paths relative to install prefix. But setting the variables as PATH causes them to be resolved relative to current directory at least on windows thus preventing them to be used that way.  Use of absolute paths is still supported.

* When available use CutterConfig.cmake from Cutter installation instead of custom code in FindCutter.  In future it will be possible to remove FindCutter.cmake completely. 

* Remove `-FORCE:UNRESOLVED` hack. This allows performing the external symbol checking during linking as it normally happens. This means that API mismatch or some build errors can be caught during build time instead of Cutter getting killed at runtime once you open the decompiler widget.


**Test plan**

See radareorg/cutter#2422

**Closing issues**

