### PR TITLE
Fix RPATH issue in the asm/anal plugins for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,6 @@ set_target_properties(core_ghidra PROPERTIES
 		PREFIX "")
 
 
-
-# set(MACOSX_RPATH "@loader_path")
 if(BUILD_CUTTER_PLUGIN)
 	add_subdirectory(cutter-plugin)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,9 @@ endif()
 
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-string (REPLACE ";" " " LD_RPATH_STR "@loader_path")
+	string (REPLACE ";" " " LD_RPATH_STR "@loader_path")
 else()
-string (REPLACE ";" " " LD_RPATH_STR "$ORIGIN")
+	string (REPLACE ";" " " LD_RPATH_STR "$ORIGIN")
 endif()
 
 if(BUILD_SLEIGH_PLUGIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,6 @@ add_library(asm_ghidra SHARED ${ASM_SOURCE})
 target_link_libraries(asm_ghidra core_ghidra)
 set_target_properties(asm_ghidra PROPERTIES
 		OUTPUT_NAME asm_ghidra
-		# BUILD_RPATH "\$ORIGIN"
-		# INSTALL_RPATH "\$ORIGIN"
 		BUILD_RPATH "${LD_RPATH_STR}"
 		INSTALL_RPATH "${LD_RPATH_STR}"
 		PREFIX "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,17 @@ set_target_properties(core_ghidra PROPERTIES
 		PREFIX "")
 
 
+
+# set(MACOSX_RPATH "@loader_path")
 if(BUILD_CUTTER_PLUGIN)
 	add_subdirectory(cutter-plugin)
+endif()
+
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+string (REPLACE ";" " " LD_RPATH_STR "@loader_path")
+else()
+string (REPLACE ";" " " LD_RPATH_STR "$ORIGIN")
 endif()
 
 if(BUILD_SLEIGH_PLUGIN)
@@ -87,16 +96,18 @@ add_library(asm_ghidra SHARED ${ASM_SOURCE})
 target_link_libraries(asm_ghidra core_ghidra)
 set_target_properties(asm_ghidra PROPERTIES
 		OUTPUT_NAME asm_ghidra
-		BUILD_RPATH "\$ORIGIN"
-		INSTALL_RPATH "\$ORIGIN"
+		# BUILD_RPATH "\$ORIGIN"
+		# INSTALL_RPATH "\$ORIGIN"
+		BUILD_RPATH "${LD_RPATH_STR}"
+		INSTALL_RPATH "${LD_RPATH_STR}"
 		PREFIX "")
 
 add_library(anal_ghidra SHARED ${ANAL_SOURCE})
 target_link_libraries(anal_ghidra core_ghidra)
 set_target_properties(anal_ghidra PROPERTIES
 		OUTPUT_NAME anal_ghidra
-		BUILD_RPATH "\$ORIGIN"
-		INSTALL_RPATH "\$ORIGIN"
+		BUILD_RPATH "${LD_RPATH_STR}"
+		INSTALL_RPATH "${LD_RPATH_STR}"
 		PREFIX "")
 endif()
 


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

build of asm and anal plugins in mac use a linux-specific linker flag which makes it unloadable.

```
R2_DEBUG=1 r2 -
PLUGIN LOADED 0x7fb55d93f7f0 fcn 0x109167260
Loading /Users/pancake/.local/share/radare2/plugins/asm_ghidra.dylib
r_lib_dl_open: error: /Users/pancake/.local/share/radare2/plugins/asm_ghidra.dylib (dlopen(/Users/pancake/.local/share/radare2/plugins/asm_ghidra.dylib, 9): Library not loaded: @rpath/core_ghidra.dylib
  Referenced from: /Users/pancake/.local/share/radare2/plugins/asm_ghidra.dylib
  Reason: image not found)
Cannot open library: '/Users/pancake/.local/share/radare2/plugins/asm_ghidra.dylib'
Loading /Users/pancake/.local/share/radare2/plugins/anal_ghidra.dylib
r_lib_dl_open: error: /Users/pancake/.local/share/radare2/plugins/anal_ghidra.dylib (dlopen(/Users/pancake/.local/share/radare2/plugins/anal_ghidra.dylib, 9): Library not loaded: @rpath/core_ghidra.dylib
  Referenced from: /Users/pancake/.local/share/radare2/plugins/anal_ghidra.dylib
  Reason: image not found)
```

**Test plan**

otool -l asm*.dylib | grep -C 3 RPATH
rabin2 -l asm*.dylib | grep core_ghidra

**Closing issues**

none