### PR TITLE
Fill op->type for CMP instructions

### DIFF
--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -398,6 +398,7 @@ static ut32 anal_type_XCMP(RAnal *anal, RAnalOp *anal_op, const std::vector<Pcod
 	uintb unique_off = 0;
 	PcodeOpType key_pcode = CPUI_MAX;
 
+	anal_op->type = R_ANAL_OP_TYPE_CMP;
 	for(auto iter = raw_ops.cbegin(); iter != raw_ops.cend(); ++iter)
 	{
 		if(iter->type == key_pcode_sub || iter->type == key_pcode_and)

--- a/test/db/extras/anal_ghidra
+++ b/test/db/extras/anal_ghidra
@@ -224,3 +224,38 @@ wx e731
 ao 1
 EOF
 RUN
+
+NAME=v850load
+FILE=-
+EXPECT=<<EOF
+r2ghidra
+V850:LE:32:default
+address: 0x0
+opcode: ld.w 0x4[r29], r11
+esilcost: 4
+disasm: ld.w 0x4[r29], r11
+pseudo: ld.w 0x4[r29],r11 
+mnemonic: ld.w
+mask: ffffffff
+prefix: 0
+id: 0
+bytes: 3d5f0500
+refptr: 0
+size: 4
+sign: true
+type: load
+cycles: 0
+esil: 4,r29,NUM,+,32,1,<<,1,SWAP,-,&,1,PICK,[4],r11,=,CLEAR
+family: cpu
+EOF
+CMDS=<<EOF
+e asm.cpu=v850
+e asm.bits=32
+e asm.arch=r2ghidra
+pdga
+e anal.arch
+e anal.cpu
+wx 3d5f0500
+ao 1
+EOF
+RUN

--- a/test/db/extras/anal_ghidra
+++ b/test/db/extras/anal_ghidra
@@ -193,6 +193,25 @@ RUN
 NAME=v850cmp
 FILE=-
 EXPECT=<<EOF
+r2ghidra
+V850:LE:32:default
+address: 0x0
+opcode: cmp r7, r6
+esilcost: 0
+disasm: cmp r7, r6
+pseudo: var = r7 - r6
+mnemonic: cmp
+mask: ffff
+prefix: 0
+id: 0
+bytes: e731
+refptr: 0
+size: 2
+sign: true
+type: cmp
+cycles: 0
+esil: r7,NUM,r6,NUM,-,32,1,<<,1,SWAP,-,&,4294967287,psw,NUM,&,32,1,<<,1,SWAP,-,&,r7,NUM,r6,NUM,<,1,PICK,3,2,PICK,<<,32,1,<<,1,SWAP,-,&,1,PICK,5,PICK,|,32,1,<<,1,SWAP,-,&,psw,=,r6,NUM,r7,NUM,1,PICK,3,PICK,-,32,1,<<,1,SWAP,-,&,31,4,PICK,>>,32,1,<<,1,SWAP,-,&,1,PICK,0,SWAP,>>,8,1,<<,1,SWAP,-,&,31,5,PICK,>>,32,1,<<,1,SWAP,-,&,1,PICK,0,SWAP,>>,8,1,<<,1,SWAP,-,&,31,6,PICK,>>,32,1,<<,1,SWAP,-,&,1,PICK,0,SWAP,>>,8,1,<<,1,SWAP,-,&,1,2,PICK,&,8,1,<<,1,SWAP,-,&,4294967291,psw,NUM,&,32,1,<<,1,SWAP,-,&,5,PICK,8,PICK,==,!,3,PICK,7,PICK,==,1,PICK,3,PICK,&,8,1,<<,1,SWAP,-,&,1,PICK,2,2,PICK,<<,32,1,<<,1,SWAP,-,&,1,PICK,7,PICK,|,32,1,<<,1,SWAP,-,&,psw,=,4294967293,psw,NUM,&,32,1,<<,1,SWAP,-,&,0,23,PICK,32,SWAP,SIGN,SWAP,32,SWAP,SIGN,SWAP,<,1,PICK,1,2,PICK,<<,32,1,<<,1,SWAP,-,&,1,PICK,5,PICK,|,32,1,<<,1,SWAP,-,&,psw,=,4294967294,psw,NUM,&,32,1,<<,1,SWAP,-,&,0,27,PICK,==,1,PICK,1,PICK,4,PICK,|,32,1,<<,1,SWAP,-,&,psw,=,CLEAR
+family: cpu
 EOF
 CMDS=<<EOF
 e asm.cpu=v850

--- a/test/db/extras/anal_ghidra
+++ b/test/db/extras/anal_ghidra
@@ -189,3 +189,19 @@ pd 1 @ 0x200
 ao @ 0x200| grep type
 EOF
 RUN
+
+NAME=v850cmp
+FILE=-
+EXPECT=<<EOF
+EOF
+CMDS=<<EOF
+e asm.cpu=v850
+e asm.bits=32
+e asm.arch=r2ghidra
+pdga
+e anal.arch
+e anal.cpu
+wx e731
+ao 1
+EOF
+RUN


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

When analyzing some v850 instructions, the op.type is not filled properly i would say CMP and LOAD, STORE ops are the main problematic ones from what i see.

Theres probably a better fix for this, but i would love to hear from the experts in here to get a better/more generic fix, also i think this optype deduction out of the sleigh expression should have more tests. but im impressed by how well it works out of the box after sorting out all the segfaults already fixed.

Awesome work!

**Test plan**

added a couple of tests

**Closing issues**

not sure if i spent the time to fill an issue for this
