### PR TITLE
Fix pdg when using asm.arch=r2ghidra, uses asm.cpu

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -149,7 +149,22 @@ std::string SleighIdFromCore(RCore *core)
 {
 	const char *arch = r_config_get(core->config, "asm.arch");
 	auto arch_it = arch_map.find(arch);
-	if(arch_it == arch_map.end())
-		throw LowlevelError("Could not match asm.arch " + std::string(arch) + " to sleigh arch.");
+	if(arch_it == arch_map.end()) {
+		char *cpu = strdup (r_config_get(core->config, "asm.cpu"));
+		char *colon = cpu;
+		while (*colon) {
+			if (*colon == ':') {
+				*colon = 0;
+				break;
+			}
+			*colon = tolower (*colon);
+			colon++;
+		}
+		arch_it = arch_map.find(cpu);
+		free (cpu);
+		if(arch_it == arch_map.end()) {
+			throw LowlevelError("Could not match asm.arch " + std::string(arch) + " to sleigh arch.");
+		}
+	}
 	return arch_it->second.Map(core);
 }

--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -158,9 +158,7 @@ std::string SleighIdFromCore(RCore *core)
 	}
 	auto arch_it = arch_map.find(arch);
 	if(arch_it == arch_map.end()) {
-		if(arch_it == arch_map.end()) {
-			throw LowlevelError("Could not match asm.arch " + std::string(arch) + " to sleigh arch.");
-		}
+		throw LowlevelError("Could not match asm.arch " + std::string(arch) + " to sleigh arch.");
 	}
 	return arch_it->second.Map(core);
 }

--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2019 - thestr4ng3r */
+/* radare - LGPL - Copyright 2019-2020 - thestr4ng3r */
 
 #include "ArchMap.h"
 #include <error.hh>
@@ -148,20 +148,16 @@ std::string CompilerFromCore(RCore *core)
 std::string SleighIdFromCore(RCore *core)
 {
 	const char *arch = r_config_get(core->config, "asm.arch");
+	if (!strcmp (arch, "r2ghidra")) {
+		const char *cpu = r_config_get(core->config, "asm.cpu");
+		auto arch_it = arch_map.find(cpu);
+		if(arch_it == arch_map.end()) {
+			throw LowlevelError("Could not match asm.arch " + std::string(cpu) + " to sleigh arch.");
+		}
+		return arch_it->second.Map(core);
+	}
 	auto arch_it = arch_map.find(arch);
 	if(arch_it == arch_map.end()) {
-		char *cpu = strdup (r_config_get(core->config, "asm.cpu"));
-		char *colon = cpu;
-		while (*colon) {
-			if (*colon == ':') {
-				*colon = 0;
-				break;
-			}
-			*colon = tolower (*colon);
-			colon++;
-		}
-		arch_it = arch_map.find(cpu);
-		free (cpu);
 		if(arch_it == arch_map.end()) {
 			throw LowlevelError("Could not match asm.arch " + std::string(arch) + " to sleigh arch.");
 		}

--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -148,7 +148,7 @@ std::string CompilerFromCore(RCore *core)
 std::string SleighIdFromCore(RCore *core)
 {
 	const char *arch = r_config_get(core->config, "asm.arch");
-	if (!strcmp (arch, "r2ghidra")) {
+	if (!strcmp(arch, "r2ghidra")) {
 		const char *cpu = r_config_get(core->config, "asm.cpu");
 		auto arch_it = arch_map.find(cpu);
 		if(arch_it == arch_map.end()) {

--- a/src/ArchMap.h
+++ b/src/ArchMap.h
@@ -8,5 +8,6 @@
 #include <string>
 
 std::string SleighIdFromCore(RCore *core);
+std::string SleighIdFromArch(const char *arch, int bits);
 
 #endif

--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -17,27 +17,29 @@ static int archinfo(RAnal *anal, int query)
 	// This is to check if RCore plugin set cpu properly.
 	if(!anal->cpu)
 		return -1;
-	char *cpu = strdup (SleighIdFromArch(anal->cpu, anal->bits).c_str());
+	char *cpu = strdup(SleighIdFromArch(anal->cpu, anal->bits).c_str());
 
 	ut64 length = strlen(cpu), i = 0;
 	for(; i < length && cpu[i] != ':'; ++i) {}
 	if(i == length) {
-		free (cpu);
+		free(cpu);
 		return -1;
 	}
 
-	try {
+	try
+	{
 		sanal.init(cpu, anal? anal->iob.io : nullptr, SleighAsm::getConfig(anal));
-		free (cpu);
-	} catch (const LowlevelError &e) {
+		free(cpu);
+	}
+	catch(const LowlevelError &e)
+	{
 		std::cerr << "SleightInit " << e.explain << std::endl;
-		free (cpu);
+		free(cpu);
 		return -1;
 	}
 
-	if(query == R_ANAL_ARCHINFO_ALIGN) {
+	if(query == R_ANAL_ARCHINFO_ALIGN)
 		return sanal.alignment;
-	}
 	return -1;
 }
 
@@ -1616,7 +1618,7 @@ static int sleigh_op(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, int
 	}
 	catch(const LowlevelError &e)
 	{
-		free (cpu);
+		free(cpu);
 		return 0;
 	}
 }
@@ -1792,16 +1794,19 @@ static char *get_reg_profile(RAnal *anal)
 	ut64 length = strlen(cpu), z = 0;
 	for(; z < length && cpu[z] != ':'; ++z) {}
 	if(z == length) {
-		free (cpu);
+		free(cpu);
 		return nullptr;
 	}
 
-	try {
+	try
+	{
 		sanal.init(cpu, anal? anal->iob.io: nullptr, SleighAsm::getConfig(anal));
-		free (cpu);
-	} catch (const LowlevelError &e) {
+		free(cpu);
+	}
+	catch (const LowlevelError &e)
+	{
 		std::cerr << "SleightInit " << e.explain << std::endl;
-		free (cpu);
+		free(cpu);
 		return nullptr;
 	}
 

--- a/src/asm_ghidra.cpp
+++ b/src/asm_ghidra.cpp
@@ -3,6 +3,7 @@
 #include <r_lib.h>
 #include <r_asm.h>
 #include "SleighAsm.h"
+#include "ArchMap.h"
 
 static SleighAsm sasm;
 static RIO *rio = nullptr;
@@ -37,7 +38,8 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len)
 			r_buf_free(tmp_buf);
 		}
 
-		sasm.init(a->cpu, bin? bin->iob.io : rio, SleighAsm::getConfig(a));
+		std::string sid = SleighIdFromArch(a->cpu, a->bits);
+		sasm.init(sid.c_str(), bin? bin->iob.io : rio, SleighAsm::getConfig(a));
 		sasm.check(bin? a->pc : 0, buf, len);
 		r = sasm.disassemble(op, bin? a->pc : 0);
 #ifndef DEBUG_EXCEPTIONS

--- a/test/db/extras/asm_ghidra
+++ b/test/db/extras/asm_ghidra
@@ -732,3 +732,48 @@ NOP
 NOP
 EOF
 RUN
+
+NAME=rasm2-cpu-alias
+FILE=-
+CMDS=<<EOF
+rasm2 -a r2ghidra -c x86 -d 89e1909090909090909090909090
+EOF
+EXPECT=<<EOF
+MOV ecx,esp
+NOP
+NOP
+NOP
+NOP
+NOP
+NOP
+NOP
+NOP
+NOP
+NOP
+NOP
+NOP
+EOF
+RUN
+
+NAME=r2-v850
+FILE=-
+CMDS=<<EOF
+e asm.arch=r2ghidra
+e asm.cpu=v850
+e asm.bits=32
+wx 8100e009ba154007b8a8042a400e000184ff88990c0a400faba80c0a400faca8
+pd 10
+EOF
+EXPECT=<<EOF
+            0x00000000      8100           zxb r1
+            0x00000002      e009           cmp r0, r1
+        ,=< 0x00000004      ba15           bne 0x2a
+        |   0x00000006      4007b8a8       st.b r0, -0x5748[r0]
+        |   0x0000000a      042a           mov 0x4, tp
+        |   0x0000000c      400e0001       movhi 0x100, r0, r1
+        |   0x00000010      84ff8899       jarl 0x49998, lp
+        |   0x00000014      0c0a           mov 0xc, r1
+        |   0x00000016      400faba8       st.b r1, -0x5755[r0]
+        |   0x0000001a      0c0a           mov 0xc, r1
+EOF
+RUN

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -1,5 +1,31 @@
 NAME=x86_32
 FILE=r2-testbins/elf/crackme0x05
+ARGS=-n
+EXPECT=<<EOF
+
+// WARNING: [r2ghidra] Function fcn.000003d0 has no calling convention set, args may be inaccurate.
+// WARNING: [r2ghidra] Function fcn.00000364 has no calling convention set, args may be inaccurate.
+
+void fcn.000003d0(void)
+{
+    fcn.00000364(0x8048540);
+    do {
+    // WARNING: Do nothing block with infinite loop
+    } while( true );
+}
+EOF
+CMDS=<<EOF
+s 0x3d0
+e asm.arch=r2ghidra
+e asm.bits=32
+e asm.cpu=x86
+af
+pdg
+EOF
+RUN
+
+NAME=x86_32
+FILE=r2-testbins/elf/crackme0x05
 EXPECT=<<EOF
 x86:LE:32:default:gcc
 
@@ -62,7 +88,7 @@ RUN
 NAME=x86_16
 FILE=r2-testbins/mz/unzip.exe
 EXPECT=<<EOF
-x86:LE:16:Real Mode:
+x86:LE:16:Real Mode
 
 // WARNING: Variable defined which should be unmapped: var_8h
 // WARNING: Variable defined which should be unmapped: var_4h
@@ -167,7 +193,7 @@ NAME=6502
 FILE=r2-testbins/prg/t01.prg
 ARGS=-F prg
 EXPECT=<<EOF
-6502:LE:16:default:
+6502:LE:16:default
 
 // WARNING: [r2ghidra] Function fcn.0000080e has no calling convention set, args may be inaccurate.
 


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

pdg takes the arch from asm.arch.. which is fine for capstone plugin for example. but when using the r2ghidra asm/anal plugins, this information must be parsed from asm.cpu

**Test plan**

r2 -a r2ghidra -e asm.cpu x86 -
af
pdg

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
