### PR TITLE
Update iaito plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,12 @@ set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH True)
 
 project(r2ghidra)
 
-set(RADARE2_INSTALL_PLUGDIR "lib/radare2/last" CACHE STRING "Directory to install radare2 plugin into")
-set(CUTTER_INSTALL_PLUGDIR "share/RadareOrg/Cutter/plugins/native" CACHE STRING "Directory to install Cutter plugin into")
+set(RADARE2_INSTALL_PLUGDIR "share/radare2/plugins" CACHE STRING "Directory to install radare2 plugin into")
+set(IAITO_INSTALL_PLUGDIR "share/radareorg/iaito/plugins/native" CACHE STRING "Directory to install iaito plugin into")
 
-set(CUTTER_SOURCE_DIR CUTTER_SOURCE_DIR-NOTFOUND CACHE STRING "Root directory of Cutter source")
+set(IAITO_SOURCE_DIR IAITO_SOURCE_DIR-NOTFOUND CACHE STRING "Root directory of iaito source")
 
-option(BUILD_CUTTER_PLUGIN "Build r2ghidra plugin for Cutter" OFF)
+option(BUILD_IAITO_PLUGIN "Build r2ghidra plugin for iaito" OFF)
 option(BUILD_DECOMPILE_EXECUTABLE "Build \"decompile\" executable as used by Ghidra (not needed for r2)" OFF)
 option(BUILD_DECOMPILE_CLI_EXECUTABLE "Build REPL decompiler (not needed for r2)" OFF)
 option(BUILD_SLASPECS "Build Sleigh specs for architectures from Ghidra" ON)
@@ -97,8 +97,8 @@ set_target_properties(core_ghidra PROPERTIES
 		PREFIX "")
 
 
-if(BUILD_CUTTER_PLUGIN)
-	add_subdirectory(cutter-plugin)
+if(BUILD_IAITO_PLUGIN)
+	add_subdirectory(iaito-plugin)
 endif()
 
 

--- a/iaito-plugin/R2GhidraDecompiler.cpp
+++ b/iaito-plugin/R2GhidraDecompiler.cpp
@@ -18,7 +18,7 @@ R2GhidraDecompiler::R2GhidraDecompiler(QObject *parent)
 void R2GhidraDecompiler::decompileAt(ut64 addr)
 {
 	task = DecompilerRunning;
-	RAnnotatedCode *code = r2ghidra_decompile_annotated_code(Core()->core(), addr);
+	RCodeMeta *code = r2ghidra_decompile_annotated_code(Core()->core(), addr);
 	emit finished(code); //Here, we emit RAnnotatedCode *code or by value
 	task = DecompilerFinished;
 }


### PR DESCRIPTION
Iaito plugin was not directly compileable since top level cmake files still referred to cutter despite not being there.
Also there was some change in r2 classes (RAnnotatedCode -> RCodeMeta) that also needs to be reflected in the iaito plugin.
This pull request fixes those things.