### PR TITLE
Include <memory> to fix std::unique_ptr build issue

### DIFF
--- a/src/R2Scope.h
+++ b/src/R2Scope.h
@@ -4,6 +4,7 @@
 #define R2GHIDRA_R2SCOPE_H
 
 #include <database.hh>
+#include <memory>
 
 #include <r_types.h>
 


### PR DESCRIPTION
I got this build issue suddenly, and although it's not clear to me exactly why this happened (or did not happen before), the compiler suggested a fix that worked :)

Below is the output from `make` before applying the fix:

```
> $ make
cp -f ghidra-processors.txt.default ghidra-processors.txt
make -C src
make[1]: Entering directory '/home/zutle/code/r2ghidra/src'
c++ -fPIC -I../third-party/pugixml/src/ -g -std=c++11 -DR2GHIDRA_SLEIGHHOME_DEFAULT=\"/home/zutle/.local/share/radare2/plugins/r2ghidra_sleigh\" -w -fPIC -Wshadow -I../ghidra-native/src/decompiler -I. -I/usr/local/include/libr -I/usr/local/include/libr/sdb -c R2Architecture.cpp
In file included from R2Architecture.cpp:4:
R2Scope.h:23:14: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   23 |         std::unique_ptr<uint8> next_id;
      |              ^~~~~~~~~~
R2Scope.h:7:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
    6 | #include <database.hh>
  +++ |+#include <memory>
    7 | 
R2Scope.h: In member function ‘uint8 R2Scope::makeId() const’:
R2Scope.h:25:41: error: ‘next_id’ was not declared in this scope
   25 |         uint8 makeId() const { return (*next_id)++; }
      |                                         ^~~~~~~
make[1]: *** [Makefile:87: R2Architecture.o] Error 1
make[1]: Leaving directory '/home/zutle/code/r2ghidra/src'
make: *** [Makefile:8: all] Error 2
```
