### PR TITLE
Some more build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  R2V: 5.8.0
+  R2V: 5.8.2
 
 on:
   push:

--- a/dist/debian/deb.mk
+++ b/dist/debian/deb.mk
@@ -91,16 +91,16 @@ ${PACKAGE_DIR}/build: ${PACKAGE_DIR}/debian-binary ${PACKAGE_DIR}/control \
 	rm -rf $@
 	mkdir $@
 	cp ${PACKAGE_DIR}/debian-binary $@/
-	cd ${PACKAGE_DIR}/control && tar cJvf $@/control.tar.gz *
+	cd ${PACKAGE_DIR}/control && tar cJvf $@/control.tar.xz *
 	cd ${PACKAGE_DIR}/data && \
 		COPY_EXTENDED_ATTRIBUTES_DISABLE=true \
 		COPYFILE_DISABLE=true \
-		tar cpJvf $@/data.tar.gz *
+		tar cpJvf $@/data.tar.xz *
 
 # Convert GNU ar to BSD ar that debian requires.
 # Note: Order of files within ar archive is important!
 ${PACKAGE_DIR}/${PACKAGE}_${VERSION}_${ARCH}.deb: ${PACKAGE_DIR}/build
-	ar -rc $@ $</debian-binary $</control.tar.gz $</data.tar.gz
+	ar -rc $@ $</debian-binary $</control.tar.xz $</data.tar.xz
 	#sed -e 's|^\([^/]\+\)/ \(.*\)|\1  \2|g' $@tmp > $@fail
 	#rm -f $@tmp
 	#mv $@fail $@

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   ['c', 'cpp'],
 license : 'LGPL3',
 meson_version : '>=0.50.1',
-version : '5.8.0',
+version : '5.8.2',
 default_options : ['c_std=c11', 'cpp_std=c++11']
 )
 


### PR DESCRIPTION
**Description**

More fixes for the build

The debian build as made, is somewhat broken, and there is a rogue 5.8.0 string in core_ghidra.so

Found some more 5.8.0 version strings from the previous build, and changed them to 5.8.2
Fixed a couple of missed changes gz -> xz in the debian build