### PR TITLE
r2ghidra compiling on msys2

### DIFF
--- a/configure
+++ b/configure
@@ -497,7 +497,14 @@ for A in ${ENVWORDS} ; do
 	[ "${A}" = VPATH ] && continue
 	[ "${A}" = srcdir ] && continue
 	eval "VAR=\$${A}"
-	VAR="`echo ${VAR} | sed -e 's/\,/\\\,/g'`"
+	case "${HOST_OS}" in
+	mingw*|cygwin*|msys*)
+		VAR="`echo ${VAR} | sed -e 's/\\\\/\\\\\\\\/g' -e 's/\,/\\\,/g'`"
+		;;
+	*)
+		VAR="`echo ${VAR} | sed -e 's/\,/\\\,/g'`"
+		;;
+	esac
 	[ $COUNT = 10 ] && COUNT=0 && SEDFLAGS="${SEDFLAGS}' -e '"
 	COUNT=$(($COUNT+1))
 	SEDFLAGS="${SEDFLAGS}s,@${A}@,${VAR},g;"


### PR DESCRIPTION
$ r2 -H R2_LIBR_PLUGINS
C:\rtools44\ucrt64\lib\plugins

so basically r2 returns path with backslashes but sed trims it away and in the end config.mk is nonsensical if you use msys2

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
but I know this file is generated.... so this pr is useless, where does it get the template from?