### PR TITLE
WIP: random changes to get some improvements or not

### DIFF
--- a/src/PcodeFixupPreprocessor.h
+++ b/src/PcodeFixupPreprocessor.h
@@ -10,6 +10,10 @@ class PcodeFixupPreprocessor
 	public:
 		static void fixupSharedReturnJumpToRelocs(RAnalFunction *function, ghidra::Funcdata *func, RCore *core, R2Architecture &arch);
 		static bool applyFunctionSignature(const char *funcName, const ghidra::Address &addr, R2Architecture &arch);
+/// Detect simple constant stores into stack slots followed by a load into a call argument,
+    /// and replace the load with the constant to inline argument values.
+    static void fixupConstantCallArguments(RAnalFunction *function, ghidra::Funcdata *func, RCore *core, R2Architecture
+    &arch);
 };
 
 #endif

--- a/src/R2PrintC.cpp
+++ b/src/R2PrintC.cpp
@@ -22,11 +22,11 @@ PrintLanguage *R2PrintCCapability::buildLanguage(Architecture *glb) {
 
 R2PrintC::R2PrintC(Architecture *g, const string &nm) : PrintC(g, nm) {
  	option_NULL = true;
-//	option_space_after_comma = true;
+// option_space_after_comma = true;
 // 	option_nocasts = true;
-///  option_convention = true;
-///  option_hide_exts = true;
-///  option_inplace_ops = false;
+option_convention = true;
+option_hide_exts = true;
+option_inplace_ops = false;
 ///  option_nocasts = false;
 ///  option_NULL = false;
 ///  option_unplaced = false;

--- a/src/R2PrintC.h
+++ b/src/R2PrintC.h
@@ -4,14 +4,21 @@
 #define R2GHIDRA_R2PRINTC_H
 
 #include <printc.hh>
+#include <map>
 
 using namespace ghidra;
 
 class R2PrintC : public PrintC {
 protected:
-	void pushUnnamedLocation(const Address &addr, const Varnode *vn,const PcodeOp *op) override;
+   void pushUnnamedLocation(const Address &addr, const Varnode *vn,const PcodeOp *op) override;
+   /// Skip raw stores of constant arguments to stack for better call syntax
+   void opStore(const PcodeOp *op) override;
+   /// Inline loads from stack of previously stored constants
+   void opLoad(const PcodeOp *op) override;
 	// void opCast(const PcodeOp *op) override;
 
+   /// Map stack offset to constant value for inlining
+   std::map<uintb,uintb> constMap;
 public:
 	explicit R2PrintC(Architecture *g, const string &nm = "c-language");
 	void setOptionNoCasts(bool nc);

--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -172,9 +172,10 @@ FunctionSymbol *R2Scope::registerFunction(RAnalFunction *fcn) const {
 
 	RangeList varRanges; // to check for overlaps
 	RList *vars = NULL;
-	
+	// If enabled, pull in radare2's local variable analysis for this function
 	if (r_config_get_b (core->config, "r2ghidra.vars")) {
-		r_anal_var_all_list (core->anal, fcn);
+		// Retrieve all variables (stack slots, registers, etc.)
+		vars = r_anal_var_all_list (core->anal, fcn);
 	}
 	auto stackSpace = arch->getStackSpace ();
 

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -74,7 +74,7 @@ CV cfg_var_rawptr     ("rawptr",      "true",     "Show unknown globals as raw a
 CV cfg_var_verbose    ("verbose",     "false",    "Show verbose warning messages while decompiling");
 CV cfg_var_casts      ("casts",       "false",    "Show type casts where needed");
 CV cfg_var_fixups     ("fixups",      "false",    "Apply pcode fixups");
-CV cfg_var_roprop     ("roprop",      "0",        "Propagate read-only constants (0,1,2,3,4)");
+CV cfg_var_roprop     ("roprop",      "3",        "Propagate read-only constants (0=off,1=pointer-scan,2=pointer-scan,3=section,4=all)");
 CV cfg_var_timeout    ("timeout",     "0",        "Run decompilation in a separate process and kill it after a specific time");
 
 
@@ -174,6 +174,8 @@ static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstr
 
 	if (cfg_var_fixups.GetBool (core->config)) {
 		PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(function, func, core, arch);
+		// Inline simple constant arguments stored to stack
+		PcodeFixupPreprocessor::fixupConstantCallArguments(function, func, core, arch);
 	}
 
 	int res;


### PR DESCRIPTION
```
     49  void PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(RAnalFunction *function, Funcdata *func, RCore *core, R2Architecture &arch) {
     50    // Directly iterate through the function's instruction bytes
     51    ut64 addr = function->addr;
     ...
     30    ut64 size = r_anal_function_linear_size (function);
     31    ut64 end = addr + size;
     32
     33  #if 0
     34    auto ops = func->getBasicBlocks();
     35    func->getFuncProto().setNoReturn(true);
     36    // TODO: iterate over ghidra basic blocks or r2 info
     37    func->getFuncProto().setModel("__cdecl");
     38  #endif



func->getOverride().insertFlowOverride(Address(arch.getDefaultCodeSpace(), addr), Override::CALL_RETURN);








     ---------------



	     │@@ Symbol *R2Scope::registerFlag(RFlagItem *flag) const {                                                                    │
│-    // Handle imported function reloc flags: create a full function symbol with prototype                                   │
│-    // if (flag->space && std::string(R_FLAGS_FS_RELOC) == flag->space->name && flag->realname)                             │
│-    if (flag->space && flag->realname) {                                                                                    │
│-        // Build <mapsym> XML for function                                                                                  │
│-        Document doc;                                                                                                       │
│-        doc.setName("mapsym");                                                                                              │
│-        // Function element                                                                                                 │
│-        Element *funcEl = child(&doc, "function", {                                                                         │
│-            {"name", flag->realname},                                                                                       │
│-            {"size", "1"},                                                                                                  │
│-            {"id", hex(makeId())}                                                                                           │
│-        });                                                                                                                 │
│-        // Address                                                                                                          │
│-        child(&doc, "addr", {                                                                                               │
│-            {"space", arch->getDefaultCodeSpace()->getName()},                                                              │
│-            {"offset", hex(flag->offset)}                                                                                   │
│-        });                                                                                                                 │
│-        // Prototype stub (default void return)                                                                             │
│-        Element *protEl = child(funcEl, "prototype", {{"extrapop","0"},{"model","unknown"}});                               │
│-        Element *retEl = child(protEl, "returnsym");                                                                        │
│-        child(retEl, "addr", {{"space", arch->getDefaultCodeSpace()->getName()},{"offset", hex(flag->offset)}});            │
│-        child(retEl, "typeref", {{"name","void"}});                                                                         │
│-        // Decode and add function symbol                                                                                   │
│-        XmlDecode dec(arch, &doc);                                                                                          │
│-        auto sym = cache->addMapSym(dec);                                                                                   │
│-        return dynamic_cast<FunctionSymbol*>(sym);                                                                          │
│-    }




│-                        pieces.intypes.push_back(fmtType);                                                                  │
│-                        pieces.innames.push_back("format");                                                                 │
│-                        pieces.intypes.push_back(nullptr);                                                                  │
│-                        pieces.innames.push_back("...");                                                                    │
│-                        pieces.firstVarArgSlot = 1;



    Ghidra’s getVarnodeValue mechanism and show up as literal arguments in calls.

    Action: To replicate that in the current r2ghidra plugin, you need to:

        * Expose `r2ghidra.vars` (already exists) and default it to `true`, or document that users must set it.
        * In your R2Scope (in src/R2Scope.cpp), wire up RAnalVar fetch exactly like in rz-ghidra’s RizinScope: iterate over the RAnalVars, and for each with a constant initial value, call `context->setVariable()` (or equivalent) before decompiling.

    I’ll draft a minimal patch so that when r2ghidra.vars=1, r2’s stack‐slot constants are fed into Ghidra:

        --- a/src/R2Scope.cpp
        +++ b/src/R2Scope.cpp
        @@ -170,6 +170,15 @@
             RList *vars = NULL;
             if (r_config_get_b (core->config, "r2ghidra.vars")) {
                 vars = r_anal_var_get (core->anal, func->addr);
        +        // Seed Ghidra’s context with any constant stack slots
        +        for (auto *v : r_list_to_vector<RAnalVar>(vars)) {
        +            if (v->type == R_ANAL_VAR_TYPE_STACK && v->value_is_const) {
        +                ut64 off = v->stack_offset >= 0
        +                    ? v->stack_offset
        +                    : arch->getStackSpace()->getHighest() + v->stack_offset + 1;
        +                Address addr(arch->getDefaultCodeSpace(), off);
        +                context->setVariable( addr, v->constant_value );
        +            }
        +        }
             }

```