### PR TITLE
Add Sleigh architecture file generation to Meson build

### DIFF
--- a/ghidra/meson.build
+++ b/ghidra/meson.build
@@ -1,0 +1,25 @@
+fs = import('fs')
+proc_file = meson.current_source_dir() / '..' / 'ghidra-processors.txt.default'
+proc_list = fs.read(proc_file).strip().split('\n')
+
+proc_dir = meson.current_source_dir() / '..' / 'subprojects' / 'ghidra-native' / 'src' / 'Processors'
+sleigh_dir = r2_plugdir / 'r2ghidra_sleigh'
+
+foreach proc : proc_list
+  proc = proc.strip()
+  if proc != '' and not proc.startswith('#')
+    custom_target('sleigh-' + proc,
+      command: [sleighc_exe, '-a', proc_dir / proc],
+      output: proc + '.stamp',
+    )
+
+    lang_dir = proc_dir / proc / 'data' / 'languages'
+    if fs.is_dir(lang_dir)
+      install_subdir(lang_dir,
+        install_dir: sleigh_dir,
+        strip_directory: true,
+        exclude_directories: ['*'],
+      )
+    endif
+  endif
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -122,3 +122,6 @@ r2ghidra_core_plugin = shared_library('core_r2ghidra',
   install: true,
   install_dir: r2_plugdir
 )
+
+sleighc_exe = ghidra.get_variable('sleighc_exe')
+subdir('ghidra')


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Bring Meson/Ninja build closer to parity with ACR/Make by implementing compilation of .slaspec files and installation of architecture specifications.

One caveat is that the files are compiled in the source tree rather than in the build directory, and that they are compiled during installation rather than during build. Not sure how to address this without having to explicitly specify every single generated file.

Disclaimer: Produced with assistance of Claude Code.