### PR TITLE
Reap forked child in timeout path to avoid zombie processes

### DIFF
--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -17,6 +17,11 @@
 
 #include <libdecomp.hh>
 
+#if __UNIX__
+#include <errno.h>
+#include <sys/wait.h>
+#endif
+
 #include <vector>
 #include <mutex>
 
@@ -680,6 +685,7 @@ static void _cmd(RCore *core, const char *input) {
 		} else {
 			fd_set rfds;
 			struct timeval tv;
+			int wstatus = 0;
 			tv.tv_sec = timeout / 1000;
 			tv.tv_usec = (timeout - (tv.tv_sec * 1000)) * 1000;
 			FD_ZERO (&rfds);
@@ -694,6 +700,8 @@ static void _cmd(RCore *core, const char *input) {
 			} else {
 				eprintf ("Timeout\n");
 				kill (pid, 9);
+			}
+			while (waitpid (pid, &wstatus, 0) == -1 && errno == EINTR) {
 			}
 			fflush (stderr);
 			fflush (stdout);


### PR DESCRIPTION
### Motivation

- The timeout wrapper in `_cmd()` forks a child to run the decompiler when `r2ghidra.timeout > 0` but did not call `wait()`/`waitpid()`, leaving zombie processes that can exhaust the process table under repeated use.

### Description

- Add UNIX-only includes for `errno.h` and `sys/wait.h` in `src/core_ghidra.cpp` to support `waitpid()` and `errno` checks.
- Introduce a `wstatus` variable and a `while (waitpid(pid, &wstatus, 0) == -1 && errno == EINTR) {}` loop in the parent after the `select()`/`kill()` sequence so the child is always reaped whether it completed normally or was killed on timeout.
- Keep the change limited to the existing fork-based timeout path and confined to `#if __UNIX__` so non-UNIX behavior is unchanged.

### Testing

- Ran `git diff --check` to validate there are no whitespace/error issues and it completed successfully.
- Committed the change locally with a message confirming the fix, and the repository diff shows the expected inserts of headers and the `waitpid()` loop.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab19d8ff883318935bfbd21c1bf79)