### PR TITLE
Fix UB in shared tolower helper for non-ASCII bytes

### DIFF
--- a/src/R2Utils.h
+++ b/src/R2Utils.h
@@ -21,8 +21,8 @@ template<typename T, typename F> void r_interval_tree_foreach_cpp(RIntervalTree 
 }
 
 static inline std::string tolower(std::string str) {
-	std::transform (str.begin (), str.end (), str.begin (), [](int c) {
-		return tolower (c);
+	std::transform (str.begin (), str.end (), str.begin (), [](unsigned char c) {
+		return static_cast<char>(std::tolower (c));
 	});
 	return str;
 }


### PR DESCRIPTION
### Motivation
- The shared lowercase helper forwarded signed-`char` values directly to `std::tolower`, which is undefined behavior for negative `char` values (bytes >= 0x80) and can crash when normalizing user-controlled arch/cpu strings.

### Description
- In `src/R2Utils.h` change the `std::transform` lambda to accept `unsigned char` and call `std::tolower` on that value, then cast the result back to `char`, eliminating the undefined behavior while preserving ASCII behavior.

### Testing
- Attempted automated builds with `cmake -S . -B build && cmake --build build -j2` and `meson setup builddir && meson compile -C builddir`, but the environment lacks the expected build setup (`CMakeLists.txt` not at repo root) and `meson` is not installed, so no full build could be executed; the patch is minimal and limited to `src/R2Utils.h`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab275d7048331bd884109580ee4c7)