### PR TITLE
Fix memory leak in archinfo by freeing slid_arch allocation

### DIFF
--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -70,25 +70,32 @@ extern "C" int archinfo(RArchSession *as, ut32 query) {
 	RCore *Gcore = (RCore *)io->coreb.core;
 #endif
 	char *arch = slid_arch (Gcore->anal); // is this initializing sanal global ptr?
+	int ret = 1;
 	if (sanal != nullptr) {
 		switch (query) {
 #if R2_VERSION_NUMBER >= 50909
 		case R_ARCH_INFO_MAXOP_SIZE:
-			return sanal->maxopsz;
+			ret = sanal->maxopsz;
+			break;
 		case R_ARCH_INFO_MINOP_SIZE:
-			return sanal->minopsz;
+			ret = sanal->minopsz;
+			break;
 #else
 		case R_ARCH_INFO_MAX_OP_SIZE:
-			return sanal->maxopsz;
+			ret = sanal->maxopsz;
+			break;
 		case R_ARCH_INFO_MIN_OP_SIZE:
-			return sanal->minopsz;
+			ret = sanal->minopsz;
+			break;
 #endif
 		case R_ARCH_INFO_CODE_ALIGN:
 		case R_ARCH_INFO_DATA_ALIGN:
-			return sanal->alignment;
+			ret = sanal->alignment;
+			break;
 		}
 	}
-	return 1;
+	R_FREE (arch);
+	return ret;
 }
 #else
 extern "C" int archinfo(RAnal *anal, int query) {
@@ -98,16 +105,20 @@ extern "C" int archinfo(RAnal *anal, int query) {
 		return -1;
 	}
 	char *arch = slid_arch (anal);
+	int ret = -1;
 	switch (query) {
 	case R_ANAL_ARCHINFO_MAX_OP_SIZE:
-		return sanal->maxopsz;
+		ret = sanal->maxopsz;
+		break;
 	case R_ANAL_ARCHINFO_MIN_OP_SIZE:
-		return sanal->minopsz;
+		ret = sanal->minopsz;
+		break;
 	case R_ANAL_ARCHINFO_ALIGN:
-		return sanal->alignment;
+		ret = sanal->alignment;
+		break;
 	}
-
-	return -1;
+	R_FREE (arch);
+	return ret;
 }
 #endif
 


### PR DESCRIPTION
### Motivation

- `slid_arch()` returns a heap-allocated CPU string (via `strdup`) and `archinfo()` was returning from within switch cases without freeing that string, causing a per-call memory leak in long-running services.

### Description

- Replace direct `return` statements inside `archinfo` switch cases with a local `ret` variable and `break` so cleanup always runs.
- Call `R_FREE(arch)` before returning to release the allocation returned by `slid_arch` in both the `RArchSession` and legacy `RAnal` variants of `archinfo`.
- Preserve original return semantics by initializing `ret` to the previous default return value and returning `ret` after cleanup.

### Testing

- Performed static code inspection and diff review to confirm that `R_FREE(arch)` executes on all return paths and that returned values are unchanged by the refactor.
- Ran repository file checks (`sed`/`nl` to view the updated file and `git diff`/`git status`) to verify the patch was applied.
- No build or runtime tests were executed because required build dependencies and runtime tools were not available in the environment, so dynamic validation (build/valgrind) was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab31f0e088331a5270d5cd2ab3a5b)