### PR TITLE
Free r_sys_getenv buffer for empty SLEIGHHOME to fix leak

### DIFF
--- a/src/SleighAsm.cpp
+++ b/src/SleighAsm.cpp
@@ -420,8 +420,10 @@ std::string SleighAsm::getSleighHome(RConfig * R_NULLABLE cfg) {
 			r_config_set (cfg, varname, ev);
 		}
 		std::string res (ev);
+		free (ev);
 		return res;
 	}
+	free (ev);
 
 	char *path = r_xdg_datadir ("radare2/plugins/r2ghidra_sleigh");
 	if (r_file_is_directory (path)) {


### PR DESCRIPTION
### Motivation
- `SleighAsm::getSleighHome` called `r_sys_getenv("SLEIGHHOME")`, which allocates a buffer that was only freed in the non-empty branch, causing a small heap leak when `SLEIGHHOME` is defined but empty.

### Description
- Added a `free(ev)` on the non-matching (empty) path in `src/SleighAsm.cpp` so the buffer returned by `r_sys_getenv` is always released.
- Preserved existing behavior by still copying the value into a `std::string` and setting the config when `SLEIGHHOME` is non-empty.
- Change is minimal and confined to `SleighAsm::getSleighHome` to avoid impacting other logic.

### Testing
- Inspected the modified region with `sed -n '380,470p' src/SleighAsm.cpp` and confirmed `free(ev)` is present on both branches; inspection succeeded.
- Verified the source diff to confirm only the intended lines were changed; diff inspection succeeded.
- Attempted a local build with `meson setup build`, which failed in this environment because `meson` is not installed, so a full build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab60edc548331825f4a933b4b1be2)