### PR TITLE
Remove duplicate `tricore` arch_map entry to restore `asm.cpu` variants

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -94,7 +94,6 @@ static const std::map<std::string, ArchMapper> arch_map = {
 	}},
 	{ "mips", { S("MIPS"), S("default"), bits_mapper_default, big_endian_mapper_default, 4, 4 }},
 	{ "dalvik", { S("Dalvik"), S("default"), B(32), E(false), 2, 10 }},
-	{ "tricore", { S("tricore"), S("default"), B(32), E(true) } },
 	{ "hexagon", { S("hexagon"), S("default"), B(32), E(false) } },
 	{ "wasm", { S("wasm"), S("default"), B(32) } },
 	{ "6502", { S("6502"), S("default"), B(16) } },


### PR DESCRIPTION
### Motivation
- A duplicate `"tricore"` key was present in `arch_map`, causing the first (default, big-endian) entry to mask the later `asm.cpu`-aware tricore mapper and preventing CPU-specific flavors like `tc29x`/`tc172x`/`tc176x` from being selected.

### Description
- Remove the earlier default `tricore` initializer in `src/ArchMap.cpp` so only the existing `asm.cpu`-driven `tricore` mapper remains and variant selection is restored.

### Testing
- Ran `rg -n '"tricore"' src/ArchMap.cpp` to confirm a single `tricore` entry and ran `git diff --check` and `git status --short` to validate the patch formatting and working tree; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab5fa40d48331be451c3f50b0eafb)