### PR TITLE
Fix stale RIO reuse in SleighAsm initialization

### DIFF
--- a/src/SleighAsm.cpp
+++ b/src/SleighAsm.cpp
@@ -22,7 +22,7 @@ void SleighAsm::init(const char *cpu, int bits, bool bigendian, RIO *io, RConfig
 		collectSpecfiles ();
 	}
 	std::string new_sleigh_id = SleighIdFromSleighAsmConfig (Gcore, cpu, bits, bigendian, description);
-	if (!sleigh_id.empty() && sleigh_id == new_sleigh_id) {
+	if (!sleigh_id.empty() && sleigh_id == new_sleigh_id && current_io == io) {
 		return;
 	}
 	initInner (io, new_sleigh_id);
@@ -51,6 +51,7 @@ void SleighAsm::initInner(RIO *io, std::string sleigh_id) {
 	trans.clearCache ();
 	initRegMapping ();
 	this->sleigh_id = sleigh_id;
+	current_io = io;
 }
 
 static void parseProto(const Element *el, std::vector<std::string> &arg_names, std::vector<std::string> &ret_names) {

--- a/src/SleighAsm.h
+++ b/src/SleighAsm.h
@@ -190,6 +190,7 @@ class R2Sleigh;
 class SleighAsm {
 private:
 	AsmLoadImage loader;
+	RIO *current_io = nullptr;
 	ContextInternal context;
 	DocumentStorage docstorage;
 	FileManage specpaths;


### PR DESCRIPTION
### Motivation
- The plugin reused a single `SleighAsm` instance keyed only by CPU, which allowed an `AsmLoadImage` to keep a raw `RIO*` from a closed file and risk a use-after-free when a new file with the same architecture was opened.

### Description
- Add a `RIO *current_io` field to `SleighAsm` and only skip reinitialization when both `sleigh_id` and `current_io` match the incoming `io`, forcing rebuild when the underlying file handle changes (`src/SleighAsm.h`, `src/SleighAsm.cpp`).
- Update `initInner` to set `current_io = io` after rebuilding `loader`/translator state, keeping the change minimal and preserving existing behavior when `io` is unchanged.

### Testing
- Ran repository inspection and lightweight checks and committed the minimal change, which updated `src/SleighAsm.h` and `src/SleighAsm.cpp` successfully (git commit succeeded). 
- Attempted to run `cmake -S . -B build` which failed because the repository layout lacks a top-level `CMakeLists.txt`. 
- Attempted `meson setup builddir` which failed because `meson` is not available in the environment, so no binary build or runtime ASan/valgrind reproduction was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aabb6b25f883318338a6b972f24d4a)