### PR TITLE
Restore R2Scope::isNameUsed to avoid throwing on name-uniqueness checks

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -948,6 +948,24 @@ LabSymbol *R2Scope::findCodeLabel(const Address &addr) const {
 	return nullptr;
 }
 
+
+bool R2Scope::isNameUsed(const string &name, const Scope *op2) const {
+	(void)op2;
+	if (cache->isNameUsed(name)) {
+		return true;
+	}
+
+	RCoreLock core(arch->getCore());
+	if (r_flag_get(core->flags, name.c_str())) {
+		return true;
+	}
+	if (r_anal_get_function_byname(core->anal, name.c_str())) {
+		return true;
+	}
+
+	return false;
+}
+
 Funcdata *R2Scope::resolveExternalRefFunction(ExternRefSymbol *sym) const {
 	return sym? queryFunction (sym->getRefAddr()): nullptr;
 }

--- a/src/R2Scope.h
+++ b/src/R2Scope.h
@@ -61,7 +61,7 @@ public:
 	Funcdata *findFunction(const Address &addr) const override;
 	ExternRefSymbol *findExternalRef(const Address &addr) const override;
 	LabSymbol *findCodeLabel(const Address &addr) const override;
-	bool isNameUsed(const string &name, const Scope *op2) const override { throw LowlevelError("isNameUsed unimplemented"); }
+	bool isNameUsed(const string &name, const Scope *op2) const override;
 	Funcdata *resolveExternalRefFunction(ExternRefSymbol *sym) const override;
 
 	SymbolEntry *findOverlap(const Address &addr,int4 size) const override { throw LowlevelError("findOverlap unimplemented"); }


### PR DESCRIPTION
### Motivation
- A recent change replaced `R2Scope::isNameUsed` with an inline implementation that unconditionally throws `LowlevelError`, causing decompilation to abort when the decompiler requests name-uniqueness checks.
- The goal is to restore the prior non-throwing behavior so name-collision queries on untrusted inputs do not cause availability failures during automated analysis.

### Description
- Replace the inline throwing override in `src/R2Scope.h` with a proper method declaration: `bool isNameUsed(const string &name, const Scope *op2) const override;`.
- Add an out-of-line implementation in `src/R2Scope.cpp` for `R2Scope::isNameUsed` that returns `true` if the name is present in the internal `cache`, in radare2 flags, or as a radare2 function name, and otherwise returns `false` while explicitly ignoring the `op2` parameter.
- The change re-establishes the previous semantics (non-throwing collision checks) and preserves the updated signature required by callers.

### Testing
- Ran code searches with `rg` to confirm the header no longer contains the unconditional throw and that the new implementation exists in the `.cpp` files, which succeeded.
- Performed a local diff inspection of `src/R2Scope.h` and `src/R2Scope.cpp` to verify the declaration change and the new function implementation, which succeeded.
- Attempted a build setup with Meson (`meson setup`) but the environment lacks `meson`, so a full build/test run could not be executed (build step failed due to missing `meson`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab98eb2348331acd427f4cad82b38)