### PR TITLE
Fix STORE pcode display to show correct operand order

### DIFF
--- a/src/SleighAsm.cpp
+++ b/src/SleighAsm.cpp
@@ -432,6 +432,7 @@ std::string SleighAsm::getSleighHome(RConfig * R_NULLABLE cfg) {
 			r_config_set (cfg, varname, path);
 		}
 		std::string res (path);
+		free (path);
 		return res;
 	}
 	free ((void *)path);

--- a/src/SleighAsm.cpp
+++ b/src/SleighAsm.cpp
@@ -562,7 +562,8 @@ ostream &operator<<(ostream &s, const PcodeOperand &arg) {
 }
 
 ostream &operator<<(ostream &s, const Pcodeop &op) {
-	if (op.output) {
+	bool is_store = (op.type == CPUI_STORE);
+	if (op.output && !is_store) {
 		s << *op.output << " = ";
 	}
 	s << get_opname (op.type);
@@ -571,6 +572,9 @@ ostream &operator<<(ostream &s, const Pcodeop &op) {
 	}
 	if (op.input1) {
 		s << " " << *op.input1;
+	}
+	if (is_store && op.output) {
+		s << " = " << *op.output;
 	}
 	return s;
 }

--- a/src/SleighAsm.h
+++ b/src/SleighAsm.h
@@ -180,7 +180,7 @@ public:
 		case 2: in1 = parse_vardata (vars[1]);
 		case 1: in0 = parse_vardata (vars[0]);
 		case 0: break;
-		default: throw LowlevelError ("Unexpexted isize in PcodeSlg::dump()");
+		default: throw LowlevelError ("Unexpected isize in PcodeSlg::dump()");
 		}
 
 		if (outvar) {

--- a/src/SleighAsm.h
+++ b/src/SleighAsm.h
@@ -77,12 +77,30 @@ struct PcodeOperand {
 		size = rhs.size;
 
 		switch (type) {
-		case REGISTER: name = rhs.name; break;
+		case REGISTER: new (&name) std::string(rhs.name); break;
 		case UNIQUE: /* Same as RAM */
 		case RAM: offset = rhs.offset; break;
 		case CONSTANT: number = rhs.number; break;
-		default: throw LowlevelError("Unexpected type of PcodeOperand found in operator==.");
+		default: throw LowlevelError("Unexpected type of PcodeOperand found in copy ctor.");
 		}
+	}
+
+	PcodeOperand &operator=(const PcodeOperand &rhs) {
+		if (this != &rhs) {
+			if (type == REGISTER) {
+				name.~string();
+			}
+			type = rhs.type;
+			size = rhs.size;
+			switch (type) {
+			case REGISTER: new (&name) std::string(rhs.name); break;
+			case UNIQUE:
+			case RAM: offset = rhs.offset; break;
+			case CONSTANT: number = rhs.number; break;
+			default: throw LowlevelError("Unexpected type of PcodeOperand found in operator=.");
+			}
+		}
+		return *this;
 	}
 
 	bool operator==(const PcodeOperand &rhs) const {

--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -967,8 +967,8 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 				ss << ",";
 				print_operand (iter->input0);
 				if (iter->type == CPUI_INT_SEXT) {
-					ss << "," << iter->input0->size * 8 << ",SWAP,~";
-					ss << "," << iter->output->size * 8 << ",1,<<,1,SWAP,-,&";
+					ss << "," << iter->input0->size * 8 << ",~";
+					ss << ",1," << iter->output->size * 8 << ",<<,1,-,&";
 				}
 
 				if (iter->output->is_unique()) {
@@ -1110,10 +1110,10 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 				print_operand (iter->input0);
 				if (!iter->input1->is_const ())
 					throw LowlevelError ("sleigh_esil: input1 is not consts in SUBPIECE.");
-				ss << "," << iter->input1->number * 8 << ",SWAP,>>";
+				ss << "," << iter->input1->number * 8 << ",>>";
 
 				if (iter->output->size < iter->input0->size + iter->input1->number) {
-					ss << ",1," << iter->output->size * 8 << ",1,<<,-,&";
+					ss << ",1," << iter->output->size * 8 << ",<<,1,-,&";
 				}
 				if (iter->output->is_unique()) {
 					push_stack(iter->output);
@@ -1134,10 +1134,10 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 		case CPUI_FLOAT_DIV:
 			if (iter->input0 && iter->input1 && iter->output) {
 				ss << ",";
-				print_operand (iter->input1, 0, true);
+				print_operand (iter->input0, 0, true);
 
 				ss << ",";
-				print_operand (iter->input0, 1, true);
+				print_operand (iter->input1, 1, true);
 
 				ss << ",";
 				switch (iter->type)
@@ -1173,21 +1173,21 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 			if (iter->input0 && iter->input1 && iter->output)
 			{
 				ss << ",";
-				print_operand (iter->input1);
+				print_operand (iter->input0);
 
 				ss << ",";
-				print_operand (iter->input0, 1);
+				print_operand (iter->input1, 1);
 
 				ss << ",";
 				switch (iter->type)
 				{
 					case CPUI_INT_SLESS:
-						ss << iter->input0->size * 8 << ",SWAP,~,SWAP,"
-						   << iter->input1->size * 8 << ",SWAP,~,SWAP,";
+						ss << iter->input1->size * 8 << ",~,SWAP,"
+						   << iter->input0->size * 8 << ",~,SWAP,";
 					case CPUI_INT_LESS: ss << "<"; break;
 					case CPUI_INT_SLESSEQUAL:
-						ss << iter->input0->size * 8 << ",SWAP,~,SWAP,"
-						   << iter->input1->size * 8 << ",SWAP,~,SWAP,";
+						ss << iter->input1->size * 8 << ",~,SWAP,"
+						   << iter->input0->size * 8 << ",~,SWAP,";
 					case CPUI_INT_LESSEQUAL: ss << "<="; break;
 					case CPUI_INT_NOTEQUAL: ss << "-,!,!"; break;
 					case CPUI_INT_EQUAL: ss << "-,!"; break;
@@ -1220,26 +1220,26 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 		case CPUI_INT_ADD:
 			if (iter->input0 && iter->input1 && iter->output) {
 				ss << ",";
-				print_operand (iter->input1);
+				print_operand (iter->input0);
 
 				ss << ",";
-				print_operand (iter->input0, 1);
+				print_operand (iter->input1, 1);
 				ss << ",";
 				switch (iter->type)
 				{
 					case CPUI_INT_MULT: ss << "*"; break;
 					// If divide by zero happen, give out 0
-					case CPUI_INT_DIV: ss << "SWAP,DUP,!,?{,1,|,SWAP,0,&,},/"; break;
-					case CPUI_INT_REM: ss << "SWAP,DUP,!,?{,1,|,SWAP,0,&,},%"; break;
-					case CPUI_INT_SDIV: 
-						ss << iter->input0->size * 8 << ",SWAP,~"; 
-						ss << ",SWAP," << iter->input1->size * 8 << ",SWAP,~"; 
-						ss << ",DUP,!,?{,1,|,SWAP,0,&,},~/"; 
+					case CPUI_INT_DIV: ss << "DUP,!,?{,1,|,SWAP,0,&,},/"; break;
+					case CPUI_INT_REM: ss << "DUP,!,?{,1,|,SWAP,0,&,},%"; break;
+					case CPUI_INT_SDIV:
+						ss << iter->input1->size * 8 << ",~,SWAP,"
+						   << iter->input0->size * 8 << ",~,SWAP,"
+						   << "DUP,!,?{,1,|,SWAP,0,&,},~/";
 						break;
 					case CPUI_INT_SREM:
-						ss << iter->input0->size * 8 << ",SWAP,~"; 
-						ss << ",SWAP," << iter->input1->size * 8 << ",SWAP,~"; 
-						ss << ",DUP,!,?{,1,|,SWAP,0,&,},~%"; 
+						ss << iter->input1->size * 8 << ",~,SWAP,"
+						   << iter->input0->size * 8 << ",~,SWAP,"
+						   << "DUP,!,?{,1,|,SWAP,0,&,},~%";
 						break;
 					case CPUI_INT_SUB: ss << "-"; break;
 					case CPUI_INT_ADD: ss << "+"; break;
@@ -1252,10 +1252,10 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 					case CPUI_INT_LEFT: ss << "<<"; break;
 					case CPUI_INT_RIGHT: ss << ">>"; break;
 					case CPUI_INT_SRIGHT:
-						ss << iter->input0->size * 8 << ",SWAP,~,>>>>";
+						ss << "SWAP," << iter->input0->size * 8 << ",~,SWAP,>>>>";
 						break;
 				}
-				ss << ",1," << iter->output->size * 8 << ",1,<<,-,&";
+				ss << ",1," << iter->output->size * 8 << ",<<,1,-,&";
 
 				if (iter->output->is_unique())
 					push_stack(iter->output);
@@ -1273,12 +1273,12 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 				ss << ",";
 				print_operand (iter->input1, 1);
 
-				ss << ",+," << iter->input0->size * 8 << ",1,<<,1,SWAP,-,&";
+				ss << ",+,1," << iter->input0->size * 8 << ",<<,1,-,&";
 
 				ss << ",";
 				print_operand (iter->input0, 1);
 
-				ss << ",>";
+				ss << ",<";
 
 				if (iter->output->is_unique()) {
 					push_stack(iter->output);
@@ -1293,11 +1293,11 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 			if (iter->input0 && iter->input1 && iter->output) {
 				ss << ",";
 				print_operand (iter->input0);
-				ss << "," << iter->input0->size * 8 - 1 << ",SWAP,>>,1,&";
+				ss << "," << iter->input0->size * 8 - 1 << ",>>,1,&";
 				ss << ",DUP,";
 				print_operand (iter->input1, 2);
 
-				ss << "," << iter->input1->size * 8 - 1 << ",SWAP,>>,1,&";
+				ss << "," << iter->input1->size * 8 - 1 << ",>>,1,&";
 
 				ss << ",^,1,^,SWAP";
 
@@ -1305,8 +1305,8 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 				print_operand (iter->input0, 2);
 
 				ss << ",";
-				print_operand (iter->input0, 3);
-				ss << ",+," << iter->input0->size * 8 - 1 << ",SWAP,>>,1,&"; // (a^b^1), a, c
+				print_operand (iter->input1, 3);
+				ss << ",+," << iter->input0->size * 8 - 1 << ",>>,1,&"; // (a^b^1), a, c
 				ss << ",^,&";
 				if (iter->output->is_unique()) {
 					push_stack(iter->output);
@@ -1320,24 +1320,24 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 		case CPUI_INT_SBORROW:
 			if (iter->input0 && iter->input1 && iter->output) {
 				ss << ",";
-				print_operand (iter->input1);
+				print_operand (iter->input0);
 
 				ss << ",";
-				print_operand (iter->input0, 1);
+				print_operand (iter->input1, 1);
 
-				ss << ",-," << iter->input0->size * 8 - 1 << ",SWAP,>>,1,&";
+				ss << ",-," << iter->input0->size * 8 - 1 << ",>>,1,&";
 
 				ss << ",DUP,";
 				print_operand (iter->input1, 2);
 
-				ss << "," << iter->input1->size * 8 - 1 << ",SWAP,>>,1,&";
+				ss << "," << iter->input1->size * 8 - 1 << ",>>,1,&";
 
 				ss << ",^,1,^,SWAP";
 
 				ss << ",";
 				print_operand (iter->input0, 2);
 
-				ss << "," << iter->input0->size * 8 - 1 << ",SWAP,>>,1,&"; // (r^b^1), a, r
+				ss << "," << iter->input0->size * 8 - 1 << ",>>,1,&"; // (r^b^1), a, r
 
 				ss << ",^,&";
 
@@ -1360,7 +1360,7 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 				if (iter->type == CPUI_BOOL_NEGATE) {
 					ss << ",!";
 				} else {
-					ss << ",1," << iter->output->size * 8 << ",1,<<,-,^";
+					ss << ",1," << iter->output->size * 8 << ",<<,1,-,^";
 					ss << ((iter->type == CPUI_INT_2COMP)? ",1,+": "");
 				}
 				if (iter->output->is_unique()) {
@@ -1421,7 +1421,7 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 			switch (iter->type) {
 			case CPUI_FLOAT_NAN: ss << ",NAN"; break;
 			case CPUI_FLOAT_TRUNC:
-				     ss << ",D2I,1," << iter->output->size * 8 << ",1,<<,-,&";
+				     ss << ",D2I,1," << iter->output->size * 8 << ",<<,1,-,&";
 				     break;
 			case CPUI_FLOAT_CEIL: ss << ",CEIL"; break;
 			case CPUI_FLOAT_FLOOR: ss << ",FLOOR"; break;

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -485,11 +485,7 @@ public:
 
 	void dump(const Address &addr, OpCode opc, VarnodeData *outvar, VarnodeData *vars, int4 isize) override {
 		std::stringstream ss;
-		if (opc == CPUI_STORE && isize == 3) {
-			print_vardata (ss, vars[2]);
-			ss << " = ";
-			isize = 2;
-		}
+		bool is_store = (opc == CPUI_STORE && isize == 3);
 		if (outvar) {
 			print_vardata (ss,*outvar);
 			ss << " = ";
@@ -497,24 +493,29 @@ public:
 		ss << get_opname(opc);
 		// Possibly check for a code reference or a space reference
 		ss << ' ';
+		int4 print_isize = is_store ? 2 : isize;
 		// For indirect case in SleighBuilder::dump(OpTpl *op)'s "vn->isDynamic(*walker)" branch.
-		if (isize > 1 && vars[0].size == sizeof(AddrSpace *) && vars[0].space->getName() == "const"
+		if (print_isize > 1 && vars[0].size == sizeof(AddrSpace *) && vars[0].space->getName() == "const"
 				&& (vars[0].offset >> 24) == ((uintb)vars[1].space >> 24) && trans == ((AddrSpace*)vars[0].offset)->getTrans())
 		{
 			ss << ((AddrSpace*)vars[0].offset)->getName();
 			ss << '[';
 			print_vardata (ss, vars[1]);
 			ss << ']';
-			for (int4 i = 2; i < isize; i++) {
+			for (int4 i = 2; i < print_isize; i++) {
 				ss << ", ";
 				print_vardata (ss, vars[i]);
 			}
 		} else {
 			print_vardata (ss, vars[0]);
-			for (int4 i = 1; i < isize; i++) {
+			for (int4 i = 1; i < print_isize; i++) {
 				ss << ", ";
 				print_vardata (ss, vars[i]);
 			}
+		}
+		if (is_store) {
+			ss << " = ";
+			print_vardata (ss, vars[2]);
 		}
 #if R2_VERSION_NUMBER >= 50909
 		r_cons_gprintf ("    %s\n", ss.str().c_str ());


### PR DESCRIPTION
STORE operations were printed as "value = STORE ram[addr]" instead of
the correct "STORE ram[addr] = value". Fix the operand ordering in both
PcodeRawOut::dump() (core_ghidra.cpp) and operator<< for Pcodeop
(SleighAsm.cpp).

Ported from rizinorg/rz-ghidra#378

https://claude.ai/code/session_01KchB2b4DPjq3ipyeDPafWn