### PR TITLE
Fix CPUI_INT_SCARRY ESIL emission to use input1 for second operand

### DIFF
--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -1294,7 +1294,7 @@ static void sleigh_esil(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data, 
 				print_operand (iter->input0, 2);
 
 				ss << ",";
-				print_operand (iter->input0, 3);
+				print_operand (iter->input1, 3);
 				ss << ",+," << iter->input0->size * 8 - 1 << ",SWAP,>>,1,&"; // (a^b^1), a, c
 				ss << ",^,&";
 				if (iter->output->is_unique()) {


### PR DESCRIPTION
### Motivation
- Fix a regression in signed-carry ESIL generation where the second post-XOR operand was emitted as `input0` instead of `input1`, causing incorrect signed-carry results when operands differ.

### Description
- Replace the single incorrect call in `src/anal_ghidra.cpp` so the `CPUI_INT_SCARRY` case uses `print_operand(iter->input1, 3)` instead of `print_operand(iter->input0, 3)`, restoring the intended two-operand semantics.

### Testing
- Ran `git diff --check` which passed; `meson setup builddir` failed because `meson` is not installed in the environment; `cmake -S . -B build` failed because the repository does not contain a `CMakeLists.txt` (project uses Meson/other build system).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab80c25f88331ba2b5878b1bdf1f2)