### PR TITLE
Fix #150 - Indirect call reg function calls on mips

### DIFF
--- a/src/PcodeFixupPreprocessor.cpp
+++ b/src/PcodeFixupPreprocessor.cpp
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 using namespace ghidra;
@@ -38,6 +39,65 @@ static const char* extractLibcFuncName(const char *importName) {
 #if !defined(R2_ABIVERSION) || R2_ABIVERSION < 69
 R_VEC_TYPE (RVecAnalRef, RAnalRef);
 #endif
+
+static std::string first_reg_from_values(RVecRArchValue *values) {
+	RArchValue *val = RVecRArchValue_at (values, 0);
+	return (val && val->reg)? std::string (val->reg): std::string ();
+}
+
+static std::string first_reg_from_opex(RAnalOp *op) {
+	const char *opex = r_strbuf_get (&op->opex);
+	if (R_STR_ISEMPTY (opex)) {
+		return std::string ();
+	}
+	const char *type = strstr (opex, "\"type\":\"reg\"");
+	if (!type) {
+		return std::string ();
+	}
+	const char *value = strstr (type, "\"value\":\"");
+	if (!value) {
+		return std::string ();
+	}
+	value += strlen ("\"value\":\"");
+	const char *end = strchr (value, '"');
+	if (!end || end <= value) {
+		return std::string ();
+	}
+	return std::string (value, end - value);
+}
+
+static bool op_writes_first_reg(RAnalOp *op) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
+	case R_ANAL_OP_TYPE_LOAD:
+	case R_ANAL_OP_TYPE_MOV:
+	case R_ANAL_OP_TYPE_ADD:
+	case R_ANAL_OP_TYPE_SUB:
+	case R_ANAL_OP_TYPE_LEA:
+	case R_ANAL_OP_TYPE_AND:
+	case R_ANAL_OP_TYPE_OR:
+	case R_ANAL_OP_TYPE_XOR:
+	case R_ANAL_OP_TYPE_NOT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static std::string op_first_reg(RAnalOp *op, bool dst) {
+	std::string reg = first_reg_from_values (dst? &op->dsts: &op->srcs);
+	if (!reg.empty ()) {
+		return reg;
+	}
+	if (dst && !op_writes_first_reg (op)) {
+		return std::string ();
+	}
+	return first_reg_from_opex (op);
+}
+
+static bool is_indirect_reg_call(RAnalOp *op) {
+	const ut32 base_type = op->type & R_ANAL_OP_TYPE_MASK;
+	return base_type == R_ANAL_OP_TYPE_UCALL && (op->type & R_ANAL_OP_TYPE_REG);
+}
 
 void PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(RAnalFunction *r2Func, Funcdata *ghFunc, RCore *core, R2Architecture &arch) {
 	RVecAnalRef *refs = r_anal_function_get_refs (r2Func);
@@ -69,6 +129,62 @@ void PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(RAnalFunction *r2Func
 				}
 				r_anal_op_free (op);
 			}
+		}
+	}
+	RVecAnalRef_free (refs);
+}
+
+void PcodeFixupPreprocessor::fixupResolvedIndirectCalls(RAnalFunction *r2Func, Funcdata *ghFunc, RCore *core, R2Architecture &arch) {
+	RVecAnalRef *refs = r_anal_function_get_refs (r2Func);
+	if (!refs) {
+		return;
+	}
+
+	std::unordered_map<ut64, ut64> icod_refs;
+	RAnalRef *refi;
+	R_VEC_FOREACH (refs, refi) {
+		if (R_ANAL_REF_TYPE_MASK (refi->type) == R_ANAL_REF_TYPE_ICOD && refi->addr != UT64_MAX) {
+			icod_refs[refi->at] = refi->addr;
+		}
+	}
+	if (icod_refs.empty ()) {
+		RVecAnalRef_free (refs);
+		return;
+	}
+	RVecAnalRef_free (refs);
+
+	auto space = arch.getDefaultCodeSpace ();
+	RListIter *iter;
+	void *pos;
+	r_list_foreach (r2Func->bbs, iter, pos) {
+		RAnalBlock *bb = reinterpret_cast<RAnalBlock *> (pos);
+		std::unordered_map<std::string, ut64> reg_targets;
+		for (int i = 0; i < bb->ninstr; i++) {
+			ut64 at = r_anal_bb_opaddr_i (bb, i);
+			RAnalOp *op = r_core_anal_op (core, at, R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL | R_ARCH_OP_MASK_OPEX);
+			if (!op) {
+				continue;
+			}
+			if (is_indirect_reg_call (op)) {
+				std::string reg = op_first_reg (op, false);
+				auto target = reg_targets.find (reg);
+				if (target != reg_targets.end ()) {
+					ghFunc->getOverride ().insertIndirectOverride (
+						Address (space, op->addr),
+						Address (space, target->second));
+				}
+			}
+
+			std::string dst = op_first_reg (op, true);
+			if (!dst.empty ()) {
+				auto ref = icod_refs.find (op->addr);
+				if (ref != icod_refs.end ()) {
+					reg_targets[dst] = ref->second;
+				} else {
+					reg_targets.erase (dst);
+				}
+			}
+			r_anal_op_free (op);
 		}
 	}
 }

--- a/src/PcodeFixupPreprocessor.h
+++ b/src/PcodeFixupPreprocessor.h
@@ -9,6 +9,7 @@ class PcodeFixupPreprocessor
 {
 	public:
 		static void fixupSharedReturnJumpToRelocs(RAnalFunction *function, ghidra::Funcdata *func, RCore *core, R2Architecture &arch);
+		static void fixupResolvedIndirectCalls(RAnalFunction *function, ghidra::Funcdata *func, RCore *core, R2Architecture &arch);
 		static bool applyFunctionSignature(const char *funcName, const ghidra::Address &addr, R2Architecture &arch);
 };
 

--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -677,6 +677,13 @@ FunctionSymbol *R2Scope::registerFunction(RAnalFunction *fcn) const {
 	return funcsym;
 }
 
+FunctionSymbol *R2Scope::registerFunctionFlag(RFlagItem *flag) const {
+	RCoreLock core (arch->getCore ());
+	const char *name = (core->flags->realnames && flag->realname)
+		? flag->realname : flag->name;
+	return cache->addFunction (Address (arch->getDefaultCodeSpace (), flag->addr), name);
+}
+
 Symbol *R2Scope::registerFlag(RFlagItem *flag) const {
 	RCoreLock core (arch->getCore ());
 
@@ -808,6 +815,21 @@ Symbol *R2Scope::queryR2Absolute(ut64 addr, bool contain) const {
 	}
 	if (fcn) {
 		return registerFunction (fcn);
+	}
+
+	if (r_io_is_valid_offset (core->io, addr, R_PERM_X)) {
+		const RList *flags = r_flag_get_list (core->flags, addr);
+		if (flags) {
+			RListIter *iter;
+			void *pos;
+			r_list_foreach (flags, iter, pos) {
+				auto flag = reinterpret_cast<RFlagItem *>(pos);
+				if (flag->space && flag->space->name && !strcmp (flag->space->name, R_FLAGS_FS_SECTIONS)) {
+					continue;
+				}
+				return registerFunctionFlag (flag);
+			}
+		}
 	}
 
 	RFlagItem *glob = r_anal_global_get (core->anal, addr);

--- a/src/R2Scope.h
+++ b/src/R2Scope.h
@@ -28,6 +28,7 @@ private:
 	uint8 makeId() const { return (*next_id)++; }
 
 	FunctionSymbol *registerFunction(RAnalFunction *fcn) const;
+	FunctionSymbol *registerFunctionFlag(RFlagItem *flag) const;
 	Symbol *registerFlag(RFlagItem *flag) const;
 	Symbol *registerGlobalVar(RFlagItem *glob, const char *type_str) const;
 	Symbol *queryR2Absolute(ut64 addr, bool contain) const;

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -176,6 +176,7 @@ static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstr
 	if (cfg_var_fixups.GetBool (core->config)) {
 		PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(function, func, core, arch);
 	}
+	PcodeFixupPreprocessor::fixupResolvedIndirectCalls(function, func, core, arch);
 
 	int res;
 #ifndef DEBUG_EXCEPTIONS


### PR DESCRIPTION
* Resolve flags as functions fallback reference names
* Resolve ICOD refs and override register-based calls
* Add a test

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
