### PR TITLE
Map ppc-32/ppc-64 calling conventions to the PPC proto-model

### DIFF
--- a/src/R2Architecture.cpp
+++ b/src/R2Architecture.cpp
@@ -29,7 +29,9 @@ static const std::map<std::string, std::string> cc_map = {
 	{ "amd64", "__stdcall" },
 	{ "arm64", "__cdecl" },
 	{ "arm32", "__stdcall" },
-	{ "arm16", "__stdcall" } /* not actually __stdcall */
+	{ "arm16", "__stdcall" }, /* not actually __stdcall */
+	{ "ppc-32", "__stdcall" }, /* PPC cspec default_proto: r3-r10 GPR / f1-f13 FP */
+	{ "ppc-64", "__stdcall" }
 };
 
 std::string FilenameFromCore(RCore *core) {


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

`pdg` on any ppc64/ppc32 binary emitted `//WARNING: Unknown calling convention` and scrambled parameter order.

`cc_map` only mapped x86/ARM/SH conventions, so r2's `ppc-64`/`ppc-32` cc names fell through to a null proto-model. Add them → `__stdcall`, the PPC cspec's `<default_proto>` (real ELFv1 ABI: r3–r10 / f1–f13) — same as the existing `arm32 → __stdcall` entry. Functions now decompile as `(arg1, arg2, arg3)` with no warning.