### PR TITLE
Fix build against r2 abi 109 (esilcb REsil* parameter)

### DIFF
--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -1986,8 +1986,12 @@ extern "C" int esil_sleigh_fini(REsil *esil) {
 	return true;
 }
 
+#if R2_ABIVERSION >= 109
+extern "C" bool r2ghidra_esilcb(RArchSession *as, REsil *esil, RArchEsilAction action) {
+#else
 extern "C" bool r2ghidra_esilcb(RArchSession *as, RArchEsilAction action) {
 	REsil *esil = as->arch->esil;
+#endif
 	if (!esil) {
 		R_LOG_ERROR ("esil is null");
 		return false;

--- a/src/anal_ghidra_plugin.c
+++ b/src/anal_ghidra_plugin.c
@@ -11,7 +11,11 @@ extern bool sanal_fini(RArchSession *as);
 extern RList *r2ghidra_preludes(RArchSession *as);
 extern int archinfo(RArchSession *as, ut32 query);
 extern char *r2ghidra_regs(RArchSession *as);
+#if R2_ABIVERSION >= 109
+extern bool r2ghidra_esilcb(RArchSession *as, REsil *esil, RArchEsilAction action);
+#else
 extern bool r2ghidra_esilcb(RArchSession *as, RArchEsilAction action);
+#endif
 extern char *get_reg_profile(RAnal *anal);
 bool sleigh_decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask);
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

radare2 a46760dd22 added an REsil* parameter to RArchPluginEsilCallback and bumped R2_ABIVERSION 108→109. Updates r2ghidra_esilcb to match, R2_ABIVERSION >= 109 guarded so older r2 still builds.