### PR TITLE
Fix RAnalVar vector iteration to avoid type confusion

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -189,10 +189,9 @@ struct FunctionVars {
 			return;
 		}
 		for (RAnalVarKind kind : { R_ANAL_VAR_KIND_REG, R_ANAL_VAR_KIND_BPV, R_ANAL_VAR_KIND_SPV }) {
-			RAnalVar **it;
-			R_VEC_FOREACH (&fcn->vars, it) {
-				RAnalVar *var = *it;
-				if (var && var->kind == kind) {
+			RAnalVar *var;
+			R_VEC_FOREACH (&fcn->vars, var) {
+				if (var->kind == kind) {
 					cb (var);
 				}
 			}


### PR DESCRIPTION
### Motivation
- Prevent a type-confusion crash when iterating `fcn->vars` where `R_VEC_FOREACH` yields an `RAnalVar *` element, because treating inline `RAnalVar` elements as `RAnalVar **` leads to bogus dereferences and SIGSEGV during decompilation.

### Description
- Change the `foreachVar` helper in `src/R2Scope.cpp` to iterate with `RAnalVar *var` and call `cb(var)` directly, removing the incorrect `RAnalVar **it` / `*it` dereference that caused the type confusion.
- Preserve the existing variable-kind ordering and callback behavior while removing the unsafe pointer interpretation.
- Commit applied to current branch with a corrective message.

### Testing
- Ran `git diff --check`, which reported no whitespace or diff-check issues and succeeded.  
- Ran `./configure --prefix=/tmp/r2ghidra-prefix`, which failed in this environment because `pkg-config` could not find the required `r_core` development package (build environment missing radare2 dev files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2975f6286083319d4b4145b5960368)