### PR TITLE
Iterate RAnalVar list via `r_anal_var_all_list` and `r_list_foreach_cpp` in `FunctionVars::foreachVar`

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -188,14 +188,16 @@ struct FunctionVars {
 		if (!enabled) {
 			return;
 		}
-		for (RAnalVarKind kind : { R_ANAL_VAR_KIND_REG, R_ANAL_VAR_KIND_BPV, R_ANAL_VAR_KIND_SPV }) {
-			RAnalVar **it;
-			R_VEC_FOREACH (&fcn->vars, it) {
-				RAnalVar *var = *it;
-				if (var && var->kind == kind) {
-					cb (var);
-				}
+		RList *vars = r_anal_var_all_list (core->anal, fcn);
+		if (vars) {
+			for (RAnalVarKind kind : { R_ANAL_VAR_KIND_REG, R_ANAL_VAR_KIND_BPV, R_ANAL_VAR_KIND_SPV }) {
+				r_list_foreach_cpp<RAnalVar> (vars, [&](RAnalVar *var) {
+					if (var && var->kind == kind) {
+						cb (var);
+					}
+				});
 			}
+			r_list_free (vars);
 		}
 	}
 	void collect() {


### PR DESCRIPTION
### Motivation

- Replace direct access to `fcn->vars` and `R_VEC_FOREACH` with the public API to obtain all variables, improving compatibility and safety when iterating function variables.
- Ensure the temporary `RList` returned by the API is properly freed after use to avoid leaks.

### Description

- Replace the manual per-kind `R_VEC_FOREACH` iteration over `fcn->vars` with a call to `r_anal_var_all_list(core->anal, fcn)` and iterate it using `r_list_foreach_cpp<RAnalVar>` while keeping the existing kind filter and callback invocation.
- Call `r_list_free(vars)` after iteration and handle the case where `vars` is null to preserve previous behavior.

### Testing

- Built the project and ran the automated unit test suite, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2979fd80588331960b749fc42050b3)