### PR TITLE
Seed ppc64 ELFv1 TOC base (r2) so pdg resolves TOC-relative globals

### DIFF
--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -8,6 +8,7 @@
 #include "SleighAsm.h"
 #include "ArchMap.h"
 #include "PcodeFixupPreprocessor.h"
+#include "R2Utils.h"
 #include "r2ghidra.h"
 #include <r_core.h>
 
@@ -148,6 +149,38 @@ static void ApplyPrintCConfig(RConfig *cfg, PrintC *print_c) {
 	print_c->setMaxLineSize (cfg_var_linelen.GetInt (cfg));
 }
 
+static void seedGlobalPointerRegister(R2Architecture &arch, RCore *core, RAnalFunction *function) {
+	RArchConfig *acfg = core->rasm->config;
+	const char *regname = NULL;
+	ut64 value = r_config_get_i (core->config, "anal.gp");
+	if (r_str_startswith (acfg->arch, "mips")) {
+		// mips recomputes gp from t9 in the PIC prologue, so seed t9 (callee entry by ABI), not =GP
+		regname = "t9";
+		value = function->addr;
+	} else {
+		regname = r_reg_alias_getname (core->anal->reg, R_REG_ALIAS_GP);
+		if (!regname && r_str_startswith (acfg->arch, "ppc")
+				&& acfg->bits == 64 && R_ARCH_CONFIG_IS_BIG_ENDIAN (acfg)) {
+			regname = "r2";
+		}
+	}
+	if (!regname || !value || value == UT64_MAX) {
+		return;
+	}
+	VarnodeData reg;
+	try {
+		reg = arch.translate->getRegister (regname);
+	} catch (const LowlevelError &) {
+		return;
+	}
+	AddrSpace *space = arch.getDefaultCodeSpace ();
+	ContextDatabase *cdb = arch.getContextDatabase ();
+	r_list_foreach_cpp<RAnalBlock> (function->bbs, [&](RAnalBlock *bb) {
+		TrackedSet &tset = cdb->createSet (Address (space, bb->addr), Address (space, bb->addr + bb->size));
+		tset.push_back ({ reg, value });
+	});
+}
+
 static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstream &out_stream, RCodeMeta **out_code) {
 	RAnalFunction *function = r_anal_get_fcn_in (core->anal, addr, R_ANAL_FCN_TYPE_NULL);
 	if (!function) {
@@ -171,6 +204,7 @@ static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstr
 	if (func == nullptr) {
 		throw LowlevelError ("No function in Scope");
 	}
+	seedGlobalPointerRegister (arch, core, function);
 	arch.getCore()->sleepBegin ();
 	auto action = arch.allacts.getCurrent ();
 

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -2917,14 +2917,33 @@ void sym.KillList(LL arg1)
 EOF
 RUN
 
-NAME=mips gp indirect call imports
+NAME=mips gp-relative import argument resolves under pdg
 FILE=bins/elf/boa-mips
 CMDS=<<EOF
-0x00408af4;af;pdg~sym.imp.umask,sym.imp.time,sym.websAspInit
+0x00408af4;af;pdg~sym.imp.umask,sym.imp.time
 EOF
 EXPECT=<<EOF
     sym.imp.umask(0x3f);
-    sym.imp.time(*(in_t9 + 0xec710));
-    sym.websAspInit(argc,argv);
+    sym.imp.time(*0x4f5204);
+EOF
+RUN
+
+NAME=mips t9 seed removes phantom gp args under pdg
+FILE=bins/elf/boa-mips
+CMDS=<<EOF
+0x43e43c;af;pdg
+EOF
+EXPECT=<<EOF
+
+uint32_t sym.isFileExist(uint param_1)
+
+{
+    uint32_t uVar1;
+    uchar auStack_a0 [152];
+    
+    uVar1 = sym.imp.stat(param_1,auStack_a0);
+    return ~uVar1 >> 0x1f;
+}
+
 EOF
 RUN


### PR DESCRIPTION
- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

On PPC64 ELFv1 big-endian, the TOC base lives in r2 but the decompiler has no value for it, so TOC-relative loads come out as opaque pointer math instead of named globals. Seed r2's TOC value (anal.gp) as a tracked register context over the function range before decompiling. Gated to ppc/64bit/big-endian; no-op when anal.gp is unset.