### PR TITLE
Fix build against r2 abi 110: RArch esil removed

### DIFF
--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -1579,16 +1579,10 @@ extern "C" int sleigh_op(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data,
 }
 
 extern "C" bool sleigh_decode(RArchSession *as, RAnalOp *aop, RArchDecodeMask mask) {
-	REsil *esil = as->arch->esil;
 	RBin *bin = (RBin*)as->arch->binb.bin;
 	RIO *io = (RIO*)bin->iob.io;
 	RCore *Gcore = (RCore *)io->coreb.core;
 	RAnal *anal = Gcore->anal;
-	if (bin != nullptr && esil != nullptr) {
-		io = bin->iob.io;
-		anal = esil->anal;
-		// sanal->init (cpu, bi, be, anal? anal->iob.io: nullptr, SleighAsm::getConfig (anal));
-	}
 	return sleigh_op (anal, aop, aop->addr, aop->bytes, aop->size, (RAnalOpMask)mask) > 0;
 }
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

r2 commit 9642bea286 removed the esil member from RArch and bumped the ABI to 110, breaking sleigh_decode. Guard the now-dead arch->esil path behind #if R2_ABIVERSION < 110.