### PR TITLE
Fix ppc32 small-data test expecting stripped trailing whitespace

### DIFF
--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -2981,7 +2981,7 @@ int sym.get_sda(void)
 
 {
     int unaff_r2;
-
+    
     return *(unaff_r2 + -0x8000) + *(unaff_r2 + -0x7ffc);
 }
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

The `ppc32 small-data loads stay unresolved without r2 seed` test's EXPECT had the blank line between the variable declaration and the function body stored as empty, but the decompiler emits a 4-space indent there. Restores the indent so the test matches actual output (as the other EXPECT blocks do). Sorry.