### PR TITLE
Decompile strings in executable sections as literals, not flag names

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -839,7 +839,9 @@ Symbol *R2Scope::queryR2Absolute(ut64 addr, bool contain) const {
 			void *pos;
 			r_list_foreach (flags, iter, pos) {
 				auto flag = reinterpret_cast<RFlagItem *>(pos);
-				if (flag->space && flag->space->name && !strcmp (flag->space->name, R_FLAGS_FS_SECTIONS)) {
+				if (flag->space && flag->space->name
+						&& (!strcmp (flag->space->name, R_FLAGS_FS_SECTIONS)
+						|| !strcmp (flag->space->name, R_FLAGS_FS_STRINGS))) {
 					continue;
 				}
 				if (execok || is_reloc_or_import_flag (flag)) {

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -3051,3 +3051,15 @@ ulong fcn.10000000(ulong param_1,ulong param_2)
 
 EOF
 RUN
+
+NAME=string literals render inline instead of as flag symbols
+FILE=bins/elf/crackme0x05
+CMDS=<<EOF
+aaa
+pdg @ main~printf
+EOF
+EXPECT=<<EOF
+    sym.imp.printf("IOLI Crackme Level 0x05\n");
+    sym.imp.printf("Password: ");
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

queryR2Absolute treats any flag at an executable address as a call target (registerFunctionFlag). In statically-linked binaries and firmware, .rodata shares the r-x segment with code, so `str.*` flags were registered as functions and pdg printed the flag name (e.g. `str.Hello`) instead of the string literal.

Skip string-space flags in that loop so they fall through to the existing string handling and decompile as literals again.

Restores the pdg string output asserted by the x86_16/x86_32/x86_64, comments, typedef and similar tests under test/db/extras.
