### PR TITLE
Keep r2-provided function return types instead of demoting to void

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -382,12 +382,15 @@ static void processFunctionSignature(
 {
 	std::vector<SigArg> sig_args;
 	int4 sig_first_vararg = -1;
+	bool explicit_proto = false;
 
 	{
 		RCoreLock core_lock (arch->getCore ());
 		Sdb *tdb = core_lock->anal->sdb_types;
 		char *fname = r_type_func_guess (tdb, fcn_name);
 		if (fname && r_type_func_exist (tdb, fname)) {
+			// a cc key marks an afs-set prototype; auto-inferred and library types have none
+			explicit_proto = sdb_const_get (tdb, ("func." + std::string (fname) + ".cc").c_str (), nullptr) != nullptr;
 			const int argc = r_type_func_args_count (tdb, fname);
 			for (int i = 0; i < argc; i++) {
 				char *arg_type = r_type_func_args_type (tdb, fname, i);
@@ -420,7 +423,8 @@ static void processFunctionSignature(
 		free (fname);
 	}
 
-	if (sig_args.empty ()) {
+	// a return-only prototype still needs the proto built below so its return type can be locked
+	if (sig_args.empty () && !(sig_ret_type != nullptr && explicit_proto)) {
 		return;
 	}
 
@@ -442,8 +446,8 @@ static void processFunctionSignature(
 			}
 		}
 	}
-	// variadic functions need the full proto pushed so the decompiler does call-site vararg recovery
-	have_sig_proto = sig_has_structured || (sig_first_vararg >= 0);
+	// varargs need the full proto for call-site recovery; an explicit return type must be locked so the decompiler keeps it instead of demoting to void
+	have_sig_proto = sig_has_structured || (sig_first_vararg >= 0) || (sig_ret_type != nullptr && explicit_proto);
 	if (have_sig_proto) {
 		sig_proto = protoPieces;
 	}

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -3075,3 +3075,33 @@ EXPECT=<<EOF
     sym.imp.printf("Password: ");
 EOF
 RUN
+
+NAME=return type from r2 prototype is preserved
+FILE=bins/elf/crackme0x05
+EXPECT=<<EOF
+int mycheck(int code)
+EOF
+CMDS=<<EOF
+s sym.check
+af
+afn mycheck
+afc cdecl
+'afs int mycheck(int code)
+pdg~mycheck(
+EOF
+RUN
+
+NAME=return type preserved for argument-less prototype
+FILE=bins/elf/crackme0x05
+EXPECT=<<EOF
+int mycheck(void)
+EOF
+CMDS=<<EOF
+s sym.check
+af
+afn mycheck
+afc cdecl
+'afs int mycheck(void)
+pdg~mycheck(
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

When a function has an explicitly-set prototype (afs), lock its return type via setPieces so the decompiler no longer demotes it to void.

Gated on the func.<name>.cc key so only deliberately-set prototypes are locked — auto-inferred and library types are left to the decompiler (no golden churn) - we could relax that but would probably need to update a bunch of tests. Covers argument-less prototypes too.
