### PR TITLE
Fix register-argument width and big-endian storage in pdg

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -287,13 +287,23 @@ struct FunctionVars {
 			if (a.isInvalid ()) {
 				return;
 			}
-			uintb last = a.getOffset () + type->getSize () - 1;
-			if (last < a.getOffset ()) {
+			int4 index = var->isarg ? paramIndex (a, paramSize (var, type), var) : -1;
+			if (var->isarg && index < 0) {
+				return;
+			}
+			const int4 tsize = type->getSize ();
+			// big-endian: a sub-register-width reg arg sits in the GPR's low-order (high-address) bytes
+			Address sa = a;
+			if (var->kind == R_ANAL_VAR_KIND_REG && arch->translate->isBigEndian () && tsize > 0 && tsize < default_size) {
+				sa = a + (default_size - tsize);
+			}
+			uintb last = sa.getOffset () + tsize - 1;
+			if (last < sa.getOffset ()) {
 				arch->addWarning ("Variable " + to_string (var->name) + " extends beyond the stackframe. Try changing its type to something smaller.");
 				return;
 			}
 			bool typelock = true;
-			if (overlaps (a, last)) {
+			if (overlaps (sa, last)) {
 				arch->addWarning ("Detected overlap for variable " + to_string (var->name));
 				if (var->isarg) {
 					return;
@@ -301,13 +311,9 @@ struct FunctionVars {
 				typelock = false;
 			}
 
-			int4 index = var->isarg ? paramIndex (a, paramSize (var, type), var) : -1;
-			if (var->isarg && index < 0) {
-				return;
-			}
-			ranges.insertRange (a.getSpace (), a.getOffset (), last);
+			ranges.insertRange (sa.getSpace (), sa.getOffset (), last);
 
-			Element *symbolElement = emitSymbol (symbollistElement, var->name, type, a,
+			Element *symbolElement = emitSymbol (symbollistElement, var->name, type, sa,
 				typelock ? "true" : "false", "true", var->isarg ? "0" : "-1", index,
 				var->isarg && var->kind == R_ANAL_VAR_KIND_REG, childRegRange);
 			if (var->isarg) {

--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -213,6 +213,7 @@ static bool get_builtin_spec(const R2TypeFactory *factory, const std::string &na
 	bool is_bool = false;
 	bool is_wchar = false;
 	int long_count = 0;
+	int4 explicit_size = 0;
 	while (ss >> token) {
 		if (token == "const" || token == "volatile" || token == "restrict") {
 			continue;
@@ -257,9 +258,24 @@ static bool get_builtin_spec(const R2TypeFactory *factory, const std::string &na
 			is_wchar = true;
 			continue;
 		}
+		int4 tok_size = 0;
+		if (parse_bits_suffix(token, "uint", tok_size) || parse_bits_suffix(token, "ut", tok_size)) {
+			explicit_size = tok_size;
+			is_unsigned = true;
+			continue;
+		}
+		if (parse_bits_suffix(token, "int", tok_size) || parse_bits_suffix(token, "st", tok_size)) {
+			explicit_size = tok_size;
+			continue;
+		}
 		return false;
 	}
 
+	if (explicit_size > 0) {
+		spec.size = explicit_size;
+		spec.meta = is_unsigned ? TYPE_UINT : TYPE_INT;
+		return true;
+	}
 	if (is_bool) {
 		spec.size = 1;
 		spec.meta = TYPE_BOOL;
@@ -309,6 +325,14 @@ static bool get_builtin_spec(const R2TypeFactory *factory, const std::string &na
 	return false;
 }
 
+static Datatype *base_or_unknown(R2TypeFactory *factory, int4 size, type_metatype meta) {
+	Datatype *base = factory->getBase(size, meta);
+	if (!base && meta != TYPE_UNKNOWN) {
+		base = factory->getBase(size, TYPE_UNKNOWN);
+	}
+	return base;
+}
+
 static Datatype *make_typedef(R2TypeFactory *factory, Datatype *base, const std::string &name) {
 	Datatype *typedefd = factory->getTypedef(base, name, 0, 0);
 	factory->setName(typedefd, name);
@@ -340,10 +364,7 @@ Datatype *R2TypeFactory::queryR2Base(const string &n) {
 		size = bits / 8;
 		meta = formatToMeta(r_type_format(sdb, n.c_str()));
 	}
-	Datatype *base = getBase(size, meta);
-	if (!base && meta != TYPE_UNKNOWN) {
-		base = getBase(size, TYPE_UNKNOWN);
-	}
+	Datatype *base = base_or_unknown(this, size, meta);
 	if (!base) {
 		return nullptr;
 	}
@@ -732,6 +753,12 @@ Datatype *R2TypeFactory::findById(const string &n, uint8 id, int4 sz, std::set<s
 			r = fromCString (n, nullptr, &stackTypes);
 		}
 	}
+	if (r == nullptr) {
+		BuiltinTypeSpec builtin;
+		if (get_builtin_spec (this, n, builtin)) {
+			r = base_or_unknown (this, builtin.size, builtin.meta);
+		}
+	}
 	// Fallback to a basic type if the type cannot be resolved
 	if (r == nullptr) {
 		int4 fallback_size = (sz > 0) ? sz : getSizeOfInt();
@@ -814,10 +841,7 @@ Datatype *R2TypeFactory::fromCString(const string &str, string *error, std::set<
 		if (!base) {
 			BuiltinTypeSpec builtin;
 			if (get_builtin_spec(this, manual, builtin)) {
-				Datatype *builtin_base = getBase(builtin.size, builtin.meta);
-				if (!builtin_base && builtin.meta != TYPE_UNKNOWN) {
-					builtin_base = getBase(builtin.size, TYPE_UNKNOWN);
-				}
+				Datatype *builtin_base = base_or_unknown(this, builtin.size, builtin.meta);
 				if (builtin_base) {
 					base = make_typedef(this, builtin_base, manual);
 				}

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -2979,6 +2979,41 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ppc64 sign-prefixed register arg keeps its 64-bit width under pdg
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+aa
+afvt arg1 signed int64_t @ sym..crc32_init
+pdg @ sym..crc32_init
+EOF
+EXPECT=<<EOF
+
+ulong sym..crc32_init(int64_t arg1)
+
+{
+    reloc.._mcount();
+    *(arg1 + 8) = *(*arg1 + 0x20);
+    return 0;
+}
+
+EOF
+RUN
+
+NAME=ppc64 big-endian narrow register arg maps to low-order bytes under pdg
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+aa
+afvt arg3 int @ sym..crc32_setkey
+pdg @ sym..crc32_setkey~arg3
+EOF
+EXPECT=<<EOF
+int64_t sym..crc32_setkey(int64_t arg1,int64_t arg2,int arg3)
+    if (arg3 == 4) {
+EOF
+RUN
+
 NAME=ppc32 small-data r2 seed resolves sdata globals under pdg
 FILE=bins/elf/ppc32-sda
 ARGS=-e anal.gp=0x1000801c


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

On ppc64be, register arguments were decompiled with the wrong width and byte placement, so 64-bit pointer/integer args came out split as `CONCAT44(...)` instead of a single value.

Two fixes:

- **R2Scope.cpp** — place sub-register-width reg args in the GPR's low-order (high-address) bytes on big-endian targets, instead of always at the base offset. Reorders param-index validation ahead of range insertion so the adjusted address is used consistently.
- **R2TypeFactory.cpp** — parse explicit bit-width type tokens (`intN`/`uintN`, `stN`/`utN`) so a declared type keeps its full width rather than being narrowed. Adds a `findById` fallback through the builtin spec and factors the base-or-unknown lookup into a helper.

Adds regression tests covering a sign-prefixed 64-bit reg arg keeping its width and a narrow big-endian reg arg mapping to the low-order bytes.