### PR TITLE
Add r2ghidra.compiler to select the decompiler compiler profile

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -280,25 +280,168 @@ static const std::map<std::string, ArchMapper> arch_map = {
 	{ "sbpf", { S("sBPF"), S("default"), B(64), E(false) } }
 };
 
+const char *ghidraCompilers[] = {
+	"6502.default",
+	"68000.default",
+	"6805.default",
+	"8048.default",
+	"8051.Archimedes",
+	"8051.default",
+	"8085.default",
+	"AARCH64.Visual Studio",
+	"AARCH64.default",
+	"ARM.Visual Studio",
+	"ARM.default",
+	"AppleSilicon.default",
+	"CP1600.default",
+	"CR16.default",
+	"Dalvik.default",
+	"HC05.default",
+	"HC08.default",
+	"HCS08.default",
+	"HCS12.default",
+	"JVM.default",
+	"MCS96.default",
+	"PIC24.default",
+	"STM8.default",
+	"SparcV9.default",
+	"SuperH4.Visual Studio",
+	"SuperH4.default",
+	"TI_MSP430.default",
+	"V850.default",
+	"avr32a.default",
+	"avr8.gcc",
+	"avr8.iarV1",
+	"avr8.imgCraftV8",
+	"hexagon.default",
+	"m8c.default",
+	"mips.Visual Studio",
+	"mips.default",
+	"mips.n32",
+	"mips.o32",
+	"mips.o64",
+	"old/v01stuff/toy.default",
+	"pa-risc.default",
+	"pic12c5xx.default",
+	"pic16.default",
+	"pic16c5x.default",
+	"pic17c7xx.default",
+	"pic18.default",
+	"ppc.Mac OS X",
+	"ppc.Visual Studio",
+	"ppc.default",
+	"riscv.gcc",
+	"superh.default",
+	"toy.default",
+	"toy.posStack",
+	"tricore.default",
+	"x86.Borland C++",
+	"x86.Delphi",
+	"x86.Visual Studio",
+	"x86.clang",
+	"x86.default",
+	"x86.gcc",
+	"z80.default",
+	NULL
+};
+
+// short names for the cspecs that are awkward to type via `e r2ghidra.compiler=`
+static const std::map<std::string, std::string> compiler_alias = {
+	{ "vs", "Visual Studio" },
+	{ "msvc", "Visual Studio" },
+	{ "windows", "Visual Studio" },
+	{ "mach0", "Mac OS X" },
+	{ "macos", "Mac OS X" },
+	{ "osx", "Mac OS X" },
+};
+
 static const std::map<std::string, std::string> compiler_map = {
 	{ "elf", "gcc" },
-	{ "pe", "windows" },
-	{ "mach0", "clang" }
+	{ "pe", "Visual Studio" },
+	{ "mach0", "clang" },
 };
+
+std::string findGhidraCompiler(RCore *core, const char *bin_compiler) {
+	const char *arch = r_config_get (core->config, "asm.arch");
+	if (R_STR_ISEMPTY (arch)) {
+		return std::string("default");
+	}
+	if (!strcmp (arch, "r2ghidra")) {
+		arch = r_config_get (core->config, "asm.cpu");
+	}
+	
+	char *a = strdup (arch);
+	// take arch name by splitting by the dot.
+	char *dot = strchr (a, '.');
+	if (dot) {
+		*dot = 0;
+	}
+	// asm.arch "arm" is "ARM" (32-bit) or "AARCH64" (64-bit) in Ghidra's processor naming
+	if (!strcmp (a, "arm")) {
+		free (a);
+		a = strdup (r_config_get_i (core->config, "asm.bits") == 64? "AARCH64": "ARM");
+	}
+	char *b = r_str_newf ("%s.", a);
+	free (a);
+	const char *uc = bin_compiler;
+	if (!strcmp (uc, "?")) {
+		for (int i = 0; ghidraCompilers[i]; i++) {
+			if (r_str_startswith (ghidraCompilers[i], b)) {
+				const char *c = ghidraCompilers[i] + strlen (b);
+				r_cons_printf (core->cons, "%s\n", c);
+			}
+		}
+		free (b);
+		return std::string("default");
+	}
+	if (R_STR_ISEMPTY (bin_compiler) || !strcmp (uc, "default")) {
+		bin_compiler = uc;
+	}
+	auto ali = compiler_alias.find (tolower (bin_compiler));
+	if (ali != compiler_alias.end ()) {
+		bin_compiler = ali->second.c_str ();
+	}
+	const char *goodcompiler = NULL;
+	for (int i = 0; ghidraCompilers[i]; i++) {
+		if (r_str_startswith (ghidraCompilers[i], b)) {
+			const char *c = ghidraCompilers[i] + strlen (b);
+			goodcompiler = c;
+			if (R_STR_ISEMPTY (bin_compiler) || !r_str_casecmp (c, bin_compiler)) {
+				break;
+			}
+		}
+	}
+	free (b);
+	if (goodcompiler != NULL) {
+		return std::string(goodcompiler);
+	}
+	if (r_str_startswith (arch, "x86")) {
+		return std::string("gcc");
+	}
+	return std::string("default");
+}
 
 std::string CompilerFromCore(RCore *core) {
 	if (core == nullptr) {
 		return "gcc";
 	}
+	// an explicit r2ghidra.compiler selects the cspec; "default" defers to the binary
+	const char *want = r_config_get (core->config, "r2ghidra.compiler");
+	if (R_STR_ISNOTEMPTY (want) && strcmp (want, "default")) {
+		return findGhidraCompiler (core, want);
+	}
 	RBinInfo *info = r_bin_get_info (core->bin);
 	if (!info || !info->rclass) {
 		return std::string ();
+	}
+	if (R_STR_ISNOTEMPTY (info->compiler)) {
+		// the bin's compiler string ("GCC: (GNU) 9.2.0") is not a cspec name; normalize it
+		return findGhidraCompiler (core, info->compiler);
 	}
 	auto comp_it = compiler_map.find (info->rclass);
 	if (comp_it == compiler_map.end ()) {
 		return std::string ();
 	}
-
 	return comp_it->second;
 }
 

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -56,7 +56,9 @@ public:
 
 std::vector<const ConfigVar *> ConfigVar::vars_all;
 
+std::string findGhidraCompiler(RCore *core, const char *bin_compiler);
 bool SleighHomeConfig(void *user, void *data);
+bool ConfigCompiler(void *user, void *data);
 
 #define CV static const ConfigVar
 CV cfg_var_sleighhome ("sleighhome",  "",         "SLEIGHHOME", SleighHomeConfig);
@@ -77,6 +79,7 @@ CV cfg_var_casts      ("casts",       "false",    "Show type casts where needed"
 CV cfg_var_fixups     ("fixups",      "false",    "Apply pcode fixups");
 CV cfg_var_roprop     ("roprop",      "0",        "Propagate read-only constants (0,1,2,3,4)");
 CV cfg_var_timeout    ("timeout",     "0",        "Run decompilation in a separate process and kill it after a specific time");
+CV cfg_var_compiler   ("compiler",    "default",  "Select compiler for calling conventions", ConfigCompiler);
 
 
 static std::recursive_mutex decompiler_mutex;
@@ -691,6 +694,24 @@ extern "C" bool r2ghidra_core_cmd(RCorePluginSession *cps, const char *input) {
 		return true;
 	}
 	return false;
+}
+
+bool ConfigCompiler(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	std::lock_guard<std::recursive_mutex> lock(decompiler_mutex);
+	auto node = reinterpret_cast<RConfigNode *>(data);
+	if (!strcmp (node->value, "?")) {
+		auto c = findGhidraCompiler (core, node->value);
+		// eprintf ("list compilers%c", 10);
+		return false;
+	} else {
+		auto c = findGhidraCompiler (core, node->value);
+		free (node->value);
+		node->value = strdup (c.c_str());
+		// eprintf ("%s%c", c.c_str(), 10);
+		// print c.c_str()
+	}
+	return true;
 }
 
 bool SleighHomeConfig(void */* user */, void *data) {

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -3187,3 +3187,99 @@ EXPECT=<<EOF2
     rsym.local_target();
 EOF2
 RUN
+
+NAME=r2ghidra.compiler lists the x86 compiler specs
+FILE=bins/dectest64
+CMDS=<<EOF2
+e r2ghidra.compiler=?
+EOF2
+EXPECT=<<EOF2
+Borland C++
+Delphi
+Visual Studio
+clang
+default
+gcc
+EOF2
+RUN
+
+NAME=r2ghidra.compiler lists the mips compiler specs
+FILE=bins/elf/boa-mips-mini
+CMDS=<<EOF2
+e r2ghidra.compiler=?
+EOF2
+EXPECT=<<EOF2
+Visual Studio
+default
+n32
+o32
+o64
+EOF2
+RUN
+
+NAME=r2ghidra.compiler lists the ppc compiler specs
+FILE=bins/elf/ppc64-isel
+CMDS=<<EOF2
+e r2ghidra.compiler=?
+EOF2
+EXPECT=<<EOF2
+Mac OS X
+Visual Studio
+default
+EOF2
+RUN
+
+NAME=r2ghidra.compiler normalizes an unknown name to the arch default
+FILE=bins/dectest64
+CMDS=<<EOF2
+e r2ghidra.compiler=icc
+e r2ghidra.compiler
+EOF2
+EXPECT=<<EOF2
+gcc
+EOF2
+RUN
+
+NAME=r2ghidra.compiler expands a short alias to the full cspec name
+FILE=bins/dectest64
+CMDS=<<EOF2
+e r2ghidra.compiler=windows
+e r2ghidra.compiler
+EOF2
+EXPECT=<<EOF2
+Visual Studio
+EOF2
+RUN
+
+NAME=r2ghidra.compiler keeps a valid compiler name
+FILE=bins/dectest64
+CMDS=<<EOF2
+e r2ghidra.compiler=clang
+e r2ghidra.compiler
+EOF2
+EXPECT=<<EOF2
+clang
+EOF2
+RUN
+
+NAME=r2ghidra.compiler lists the arm compiler specs
+FILE=bins/hello-arm
+CMDS=<<EOF2
+e r2ghidra.compiler=?
+EOF2
+EXPECT=<<EOF2
+Visual Studio
+default
+EOF2
+RUN
+
+NAME=r2ghidra.compiler selects the cspec in the matched language id
+FILE=bins/dectest64
+CMDS=<<EOF2
+e r2ghidra.compiler=clang
+pd:gss
+EOF2
+EXPECT=<<EOF2
+x86:LE:64:default:clang
+EOF2
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Continues/supersedes #79 (rebased onto current master — your original commit is preserved for authorship).

Adds an `r2ghidra.compiler` config var that selects the Ghidra compiler spec (calling conventions) used for decompilation, appended to the matched language id (`x86:LE:64:default:gcc`). `e r2ghidra.compiler=?` lists the cspecs available for the binary's arch; short aliases (`vs`/`msvc`/`windows` → Visual Studio, `mach0`/`macos`/`osx` → Mac OS X) make the multi-word names typeable.
  
On top of #79:
- Build against current r2 (`r_cons_printf` takes the `RCons` context).
- Map `asm.arch=arm` → `ARM`/`AARCH64` so the listing works on arm (was empty).
- Wire the config var into `CompilerFromCore` so it actually drives the cspec.
- Normalize the binary's compiler string (`GCC: (GNU) 9.2.0`) to a valid cspec name — fixes a regression where the raw string produced an invalid language id.
- Wire/expand the previously-dead `compiler_alias`; drop dead notes/code; fix a leak of the arch buffer in the `?` path.
  
Tests: 8 `db/extras/r2ghidra` cases (per-arch listing for x86/arm/mips/ppc, alias expansion, unknown-name fallback, cspec selection). 
  
Note: selecting a non-default cspec can legitimately some decompile output, so a few `db/extras` goldens may need regenerating.
