### PR TITLE
Parse pdg printf varargs via the core r_str_printfmt when ABI >= 112

### DIFF
--- a/src/PcodeFixupPreprocessor.cpp
+++ b/src/PcodeFixupPreprocessor.cpp
@@ -372,6 +372,27 @@ static bool read_format_string(RCore *core, ut64 addr, std::string &out) {
 
 // false on any conversion we can't model, so the caller skips the override
 static bool parse_format_conversions(const char *fmt, std::vector<std::string> &out) {
+#if R2_ABIVERSION >= 112
+	// the same parser, now in r2 core; bits is irrelevant in types mode
+	char *csv = r_str_printfmt (fmt, 0, 0);
+	if (!csv) {
+		return false;
+	}
+	for (char *p = csv; *p; ) {
+		char *comma = strchr (p, ',');
+		if (comma) {
+			*comma = 0;
+		}
+		out.push_back (p);
+		if (!comma) {
+			break;
+		}
+		p = comma + 1;
+	}
+	free (csv);
+	return true;
+#else
+	// TODO: drop this fallback once the minimum r2 is a release with ABI >= 112
 	for (const char *p = fmt; *p; p++) {
 		if (*p != '%') {
 			continue;
@@ -464,6 +485,7 @@ static bool parse_format_conversions(const char *fmt, std::vector<std::string> &
 		}
 	}
 	return true;
+#endif
 }
 
 static FuncProto *build_locked_proto(R2Architecture &arch, const char *cc, const char *callee,


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

#267's `parse_format_conversions` is a  copy of `r_str_printfmt`'s types-mode parser, now in r2 core. Call it directly when building against r2 with ABI >= 112 (and keep the local loop as the `#else` fallback for older r2). Verified byte-identical to the local parser.