### PR TITLE
Resolve tail calls into local functions to named calls in pdg

### DIFF
--- a/src/PcodeFixupPreprocessor.cpp
+++ b/src/PcodeFixupPreprocessor.cpp
@@ -178,7 +178,10 @@ void PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(RAnalFunction *r2Func
 	}
 	R_VEC_FOREACH (refs, refi) {
 		const char *impname = import_flag_at (core, refi->addr);
-		if (!impname) {
+		// Also fire on a tail `b` into ANY analyzed function start (named by the caller's own analysis or
+		// symbols), not just import/reloc veneers, so pdg renders `return X(args)`. Gated by r2ghidra.fixups.
+		bool localFunc = !impname && r_anal_get_function_at (core->anal, refi->addr) != NULL;
+		if (!impname && !localFunc) {
 			continue;
 		}
 		RAnalOp *op = r_core_anal_op (core, refi->at, 0);
@@ -188,7 +191,7 @@ void PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(RAnalFunction *r2Func
 		// a tail-branch into an import veneer reads as a returning call
 		if (op->type == R_ANAL_OP_TYPE_JMP) {
 			Address callAddr (space, refi->at);
-			R_LOG_INFO ("OverridingCallReturn %s", normalize_callee (impname).c_str ());
+			R_LOG_INFO ("OverridingCallReturn %s", impname? normalize_callee (impname).c_str (): "(local fcn)");
 			ghFunc->getOverride().insertFlowOverride(callAddr, Override::CALL_RETURN);
 		}
 		r_anal_op_free (op);

--- a/test/bins/Makefile
+++ b/test/bins/Makefile
@@ -25,3 +25,7 @@ elf/arm-stackchk: arm-stackchk.c
 	arm-linux-gnueabi-gcc -march=armv7-a -O1 -fstack-protector-all -nostdlib -nostartfiles \
 		-Wl,-e,checkval -Wl,--defsym,__stack_chk_fail=0x00bad000 -Wl,--defsym,__stack_chk_guard=0x00bad100 \
 		-o elf/arm-stackchk arm-stackchk.c
+
+elf/arm64-tailcall-local: arm64-tailcall-local.c
+	aarch64-linux-gnu-gcc -O2 -fPIC -nostdlib -nostartfiles -shared -fno-stack-protector \
+		-o elf/arm64-tailcall-local.so arm64-tailcall-local.c

--- a/test/bins/arm64-tailcall-local.c
+++ b/test/bins/arm64-tailcall-local.c
@@ -1,0 +1,14 @@
+/* Regression testbin for "Resolve tail calls into local functions to named calls in pdg".
+
+/* First function in .text => takes the ELF entry slot, so r2 does not relabel `target` as `entry0`
+ * (it would otherwise, since a -shared object's e_entry points at the start of .text). */
+__attribute__((used, noinline))
+void _entry_pad(void) { sink = 2; }
+
+/* hidden => the call from caller binds to a direct local `b target`, not a PLT veneer */
+__attribute__((visibility("hidden"), noinline, used))
+void target(void) { sink = 1; }
+
+/* exported => `sym.caller`; its single tail call becomes `b target` at -O2 */
+__attribute__((visibility("default")))
+void caller(void) { target(); }


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some documentation

**Description**


`pdg`'s `fixupSharedReturnJumpToRelocs` already rewrites a tail branch (`b target`) into a returning call
(`Override::CALL_RETURN`) when `target` is an **import/reloc/plt/rsym veneer** (added in @ 986e961 /
@ a721f5a ). This PR extends the exact same handling to a tail `b` into **any analyzed local function**, so a
plain intra-binary tail call renders as `target();` instead of being dropped or inlined into the caller.

The change is one extra condition in the existing ref loop: if the branch target is not an import flag but
**is a known function entry** (`r_anal_get_function_at`), treat the tail `b` the same way.

```c
const char *impname = import_flag_at (core, refi->addr);
// also fire on a tail `b` into ANY analyzed function start, not just import/reloc veneers
bool localFunc = !impname && r_anal_get_function_at (core->anal, refi->addr) != NULL;
if (!impname && !localFunc) {
    continue;
}
```

It stays gated behind `r2ghidra.fixups=true` (off by default), exactly like the existing veneer handling,
so default behaviour is unchanged.

### Why

Compilers emit `return f(args);` as a tail `b f` (no `bl`/`ret`). When `f` is a local function, stock pdg
either inlines `f`'s body into the caller (wrong scope, "Removing unreachable block" noise) or drops the
call entirely, the caller looks like it returns nothing. This is pervasive in stripped/AOT binaries where
functions are packed back-to-back and call each other by tail branch.

Concrete motivating case: **Unity IL2CPP** `libil2cpp.so` (AArch64). IL2CPP method bodies tail-call helper
methods constantly; with the veneer-only check, those calls vanish from the decompilation. With this change
they render as the real named call, which is the single biggest readability win for the output. (The
function entries are named via the caller's own analysis / user markers; the override just tells Ghidra the
`b` returns.)

### Behaviour (before / after)

`sym.caller`'s whole body is a single tail call `b sym.target` (a plain local function, not a veneer).
`pdg @ sym.caller`, `r2ghidra.fixups=true`:

```c
// before (stock pdg): the local tail b is NOT overridden -> the call is dropped and
//                     target's body is wrongly inlined into the caller
void sym.caller(void)
{
    *_reloc.sink = 1;     // <- this is target()'s body, inlined; the call to target vanished
    return;
}

// after (this PR):
void sym.caller(void)
{
    sym.target();         // <- the tail call rendered as a real named call
    return;
}
```

(Same shape as the existing `rsym.__libc_init();` veneer regression test, but for a non-veneer local
target.)

### Scope / safety

- Gated by `r2ghidra.fixups` (default off) - no change to default output.
- Only fires when the ref target is a real function entry **and** the op at the ref site is `R_ANAL_OP_TYPE_JMP`
  (a tail branch), reusing the existing veneer code path unchanged below the new condition.
- Self-recursive tail calls (`b` to the function's own entry) are handled safely - they either render as a
  returning self-call or are left as-is; they are never mis-rendered.

### Test

Adds a regression test mirroring the existing `rsym-veneer-arm.so` case but with a **plain local** tail-call target (no rsym/import). 

See `test/db/extras/r2ghidra` entry + the small AArch64 `.so` testbin (`test/bins/elf/tailcall-local-arm64.so`, < 100 KB).

Two cases (positive + negative-control), in the repo's:

```
NAME=r2ghidra resolves a local tail-call to a named call (pdg)
FILE=bins/elf/tailcall-local-arm64.so
CMDS=<<EOF2
e r2ghidra.fixups=true
aaa
pdg @ sym.caller~sym.target
EOF2
EXPECT=<<EOF2
    sym.target();
EOF2
RUN

NAME=r2ghidra leaves a local tail-call unresolved without fixups (pdg)
FILE=bins/elf/tailcall-local-arm64.so
CMDS=<<EOF2
e r2ghidra.fixups=false
aaa
pdg @ sym.caller~sink
EOF2
EXPECT=<<EOF2
    *_reloc.sink = 1;
EOF2
RUN
```

Confirmed: the positive test passes with the patch and **fails on unpatched upstream** (where the call is
dropped and `target`'s body is inlined as `*_reloc.sink = 1;`); the negative-control test documents that with
`r2ghidra.fixups=false` the override is not applied.
