### PR TITLE
Fix infinite recursion on unparseable type strings and report dead decompiler children

### DIFF
--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -737,10 +737,12 @@ Datatype *R2TypeFactory::findById(const string &n, uint8 id, int4 sz, std::set<s
 		int4 fallback_size = (sz > 0) ? sz : 1;
 		return getBase(fallback_size, TYPE_UNKNOWN);
 	}
+	// re-parsing a name already on the resolution stack would recurse forever
+	const bool revisiting = stackTypes.find (n) != stackTypes.end ();
 	if (r == nullptr) {
 		r = queryR2 (n, stackTypes);
 	}
-	if (r == nullptr) {
+	if (r == nullptr && !revisiting) {
 		const bool needs_parse =
 			n.find('*') != std::string::npos ||
 			n.rfind("const ", 0) == 0 ||

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -642,6 +642,7 @@ static void _cmd(RCore *core, const char *input) {
 			return;
 		}
 		if (pid == 0) {
+			close (fds[0]);
 			runcmd (core, input);
 			r_cons_flush (core->cons);
 			fflush (stdout);
@@ -655,12 +656,12 @@ static void _cmd(RCore *core, const char *input) {
 			tv.tv_usec = (timeout - (tv.tv_sec * 1000)) * 1000;
 			FD_ZERO (&rfds);
 			FD_SET (fds[0], &rfds);
+			// keeping our copy of the write end open would suppress eof from a crashed child until the timeout expires
+			close (fds[1]);
 			if (select (fds[0] + 1, &rfds, NULL, NULL, &tv) > 0) {
 				char ch = 0;
-				int rr = read (fds[0], &ch, 1);
-				if (rr > 0 && ch == 0x12) {
-					// eprintf ("Completed\n");
-					// return;
+				if (read (fds[0], &ch, 1) != 1 || ch != 0x12) {
+					R_LOG_ERROR ("Decompiler process died unexpectedly");
 				}
 			} else {
 				eprintf ("Timeout\n");
@@ -670,9 +671,8 @@ static void _cmd(RCore *core, const char *input) {
 			}
 			fflush (stderr);
 			fflush (stdout);
+			close (fds[0]);
 		}
-		close (fds[0]);
-		close (fds[1]);
 #else
 		R_LOG_WARN ("r2ghidra.timeout is not supported outside UNIX systems.");
 		runcmd (core, input);

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1690,3 +1690,29 @@ EXPECT=<<EOF2
         entry0(0x2a);
 EOF2
 RUN
+
+NAME=pdg survives an unparseable var type string instead of recursing
+FILE=bins/dectest64
+CMDS=<<EOF
+s sym.Aeropause
+af
+afvt arg1 int (*)(int)
+pdg~Aeropause(
+EOF
+EXPECT=<<EOF
+void sym.Aeropause(int arg1,int64_t arg2,int64_t arg3)
+EOF
+RUN
+
+NAME=afvt pointer type on a register arg applies under pdg
+FILE=bins/dectest64
+CMDS=<<EOF
+s sym.Aeropause
+af
+"afvt arg1 char *"
+pdg~Aeropause(
+EOF
+EXPECT=<<EOF
+void sym.Aeropause(char *arg1,int64_t arg2,int64_t arg3)
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Setting an unresolvable pointer-ish type on a variable (e.g. `afvt arg1 int (*)(int)`, or a corrupt quoted type) sent `R2TypeFactory::findById` and `fromCString` into infinite mutual recursion: when the parse makes no progress, findById re-parses the same string forever, ending in a stack-overflow segfault. The existing stackTypes guard only protected `queryR2`, not the parse re-entry. Now a name already on the resolution stack skips the re-parse and degrades to the int fallback with a warning.

With `r2ghidra.timeout` set, that crash looked like a hang: the parent kept its copy of the pipe write end open, so a dead child never delivered EOF and the parent slept the full timeout. The parent now closes its write end after forking and reports "Decompiler process died unexpectedly" on EOF.

Adds two regression tests in db/extras/r2ghidra_types.