### PR TITLE
Cache datatype lookups for the lifetime of a decompile

### DIFF
--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -25,7 +25,6 @@
 // - Handle declarators that need identifier placement (arrays, function pointers) when wrapping r_anal_cparse.
 // - Improve base-type signedness/alias mapping (size_t, ssize_t, uintptr_t, etc).
 // - Prefer structured r2 type APIs over raw sdb parsing when available.
-// - Add caching to avoid repeated type parsing/conversion.
 // - Drop manual libc arg typing in tests once r2 auto-applies known signatures (printf, malloc, strcmp, ...).
 #define R2G_USE_CTYPE 1
 #include "R2Utils.h"
@@ -776,17 +775,57 @@ Datatype *R2TypeFactory::findById(const string &n, uint8 id, int4 sz, std::set<s
 
 // overriden call
 Datatype *R2TypeFactory::findById(const string &n, uint8 id, int4 sz) {
+	Datatype *r = TypeFactory::findById (n, id, sz);
+	if (r) {
+		return r;
+	}
+	// the slow path ignores id and only uses sz for the fallback size, so name-keyed memoization is sound for sz <= 0
+	const bool cacheable = !n.empty () && sz <= 0;
+	if (cacheable) {
+		auto it = lookupCache.find (n);
+		if (it != lookupCache.end ()) {
+			return it->second;
+		}
+	}
 	std::set<std::string> stackTypes; // to detect recursion
-	return findById (n, id, sz, stackTypes);
+	r = findById (n, id, sz, stackTypes);
+	if (cacheable) {
+		lookupCache[n] = r;
+	}
+	return r;
 }
 
 Datatype *R2TypeFactory::fromCString(const string &str, string *error, std::set<std::string> *stackTypes) {
-	std::set<std::string> localStack;
-	std::set<std::string> *stack = stackTypes ? stackTypes : &localStack;
-	std::string type_str = normalize_ws(trim_ws(str));
-	if (type_str.empty()) {
+	std::string key = normalize_ws (trim_ws (str));
+	if (key.empty ()) {
 		return nullptr;
 	}
+	auto it = cstringCache.find (key);
+	if (it != cstringCache.end ()) {
+		const CStringCacheEntry &entry = it->second;
+		if (error && !entry.type) {
+			*error = entry.error;
+		}
+		return entry.type;
+	}
+	// results computed mid-recursion may be truncated by the recursion guard, so only cache full resolutions
+	const bool toplevel = !stackTypes || stackTypes->empty ();
+	std::string parseError;
+	Datatype *r = fromCStringInternal (key, &parseError, stackTypes);
+	if (toplevel) {
+		cstringCache[key] = { r, parseError };
+	}
+	if (error && !r) {
+		*error = parseError;
+	}
+	return r;
+}
+
+// str is already normalized and non-empty (fromCString is the only caller)
+Datatype *R2TypeFactory::fromCStringInternal(const string &str, string *error, std::set<std::string> *stackTypes) {
+	std::set<std::string> localStack;
+	std::set<std::string> *stack = stackTypes ? stackTypes : &localStack;
+	const std::string &type_str = str;
 
 	if (r_str_startswith(type_str.c_str(), "func.")) {
 		std::string func_name = type_str.substr(strlen("func."));

--- a/src/R2TypeFactory.h
+++ b/src/R2TypeFactory.h
@@ -6,6 +6,8 @@
 
 #include <type.hh>
 
+#include <map>
+
 using namespace ghidra;
 class R2Architecture;
 
@@ -13,6 +15,16 @@ class R2TypeFactory : public TypeFactory {
 private:
 	R2Architecture *arch;
 	// RParseCType *ctype;
+
+	struct CStringCacheEntry {
+		Datatype *type; // nullptr = cached resolution failure
+		std::string error;
+	};
+	// both caches live for the factory's lifetime (one decompile); Datatypes are owned by the factory
+	std::map<std::string, CStringCacheEntry> cstringCache;
+	std::map<std::string, Datatype *> lookupCache;
+
+	Datatype *fromCStringInternal(const string &str, string *error, std::set<std::string> *stackTypes);
 
 	Datatype *queryR2Struct(const string &n, std::set<std::string> &stackTypes);
 	Datatype *queryR2Union(const string &n, std::set<std::string> &stackTypes);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

R2TypeFactory re-parsed type strings on every reference (per variable, signature arg, and call-site arg); only named types were memoized by the base nametree. This caches the fall-through lookups for the factory's lifetime — exactly one decompile, so no invalidation is needed:

- cstringCache fronts fromCString, keyed on the normalized spelling; failures are cached with their error message, so unparseable types run r_anal_cparse once instead of once per reference.
- lookupCache fronts the findById fallback path (name-keyed, sz <= 0 only).

Entries are only inserted when resolution started with an empty recursion stack, so results truncated by the recursion guard (#271) are never pinned.

Output is byte-identical across x86-64/x86-32/arm64/ppc64 test binaries and the db/extras suite matches master; instrumented runs show hundreds of redundant resolutions absorbed per decompile.
