### PR TITLE
Add pdgw subcommand to write recovered names, types and signatures back into r2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ r2ghidra_sources = [
   'src/SleighAsm.cpp',
   'src/SleighInstruction.cpp',
   'src/PcodeFixupPreprocessor.cpp',
+  'src/r2harvest.cpp',
 ]
 
 incdirs = [

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ R2GHIDRA_SRCS+=CodeXMLParse.cpp
 R2GHIDRA_SRCS+=ArchMap.cpp
 R2GHIDRA_SRCS+=R2PrintC.cpp
 R2GHIDRA_SRCS+=RCoreMutex.cpp
+R2GHIDRA_SRCS+=r2harvest.cpp
 
 R2GHIDRA_SRCS+=SleighAnalValue.cpp
 R2GHIDRA_SRCS+=SleighAsm.cpp

--- a/src/R2Architecture.cpp
+++ b/src/R2Architecture.cpp
@@ -98,6 +98,14 @@ Address R2Architecture::registerAddressFromR2Reg(const char *regname) {
 	return it->second.getAddr ();
 }
 
+std::string R2Architecture::registerNameFromAddress(const Address &addr, int4 size) {
+	if (!translate || addr.isInvalid ()) {
+		return "";
+	}
+	// r2 register profiles use lowercase names, sleigh uppercase
+	return tolower (translate->getRegisterName (addr.getSpace (), addr.getOffset (), size));
+}
+
 Translate *R2Architecture::buildTranslator(DocumentStorage &store) {
 	Translate *ret = SleighArchitecture::buildTranslator (store);
 	loadRegisters(ret);

--- a/src/R2Architecture.h
+++ b/src/R2Architecture.h
@@ -35,6 +35,7 @@ public:
 
 	ProtoModel *protoModelFromR2CC(const char *cc);
 	Address registerAddressFromR2Reg(const char *regname);
+	std::string registerNameFromAddress(const Address &addr, int4 size);
 
 	void addWarning(const std::string &warning)	{ warnings.push_back(warning); }
 	const std::vector<std::string> getWarnings() const { return warnings; }

--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -929,3 +929,46 @@ Datatype *R2TypeFactory::fromCString(const string &str, string *error, std::set<
 	}
 	return result->type;
 }
+
+// reverse of fromCString: render a Datatype as an r2-parseable C type string, "" = not expressible
+std::string R2TypeFactory::toCString(Datatype *type) {
+	if (!type) {
+		return "";
+	}
+	if (type->getMetatype() == TYPE_VOID) {
+		return "void";
+	}
+	if (type->getSize() < 1) {
+		return "";
+	}
+	Datatype *base = type->getTypedef();
+	if (base) {
+		// keep real typedef names, but resolve our own scratch typedefs to what they alias
+		if (type->getName().compare(0, strlen("__r2ghidra_t_"), "__r2ghidra_t_") == 0) {
+			return toCString(base);
+		}
+		return type->getName();
+	}
+	switch (type->getMetatype()) {
+	case TYPE_PTR:
+	case TYPE_PTRREL: {
+		std::string inner = toCString(static_cast<TypePointer *>(type)->getPtrTo());
+		if (inner.empty()) {
+			return "";
+		}
+		return inner + (inner.back() == '*' ? "*" : " *");
+	}
+	case TYPE_INT:
+	case TYPE_UINT:
+	case TYPE_BOOL:
+	case TYPE_FLOAT:
+	case TYPE_STRUCT:
+	case TYPE_UNION:
+	case TYPE_ENUM_INT:
+	case TYPE_ENUM_UINT:
+		return type->getName();
+	default:
+		// TYPE_UNKNOWN would come back as a typelocked guess; arrays/partials/code are not expressible
+		return "";
+	}
+}

--- a/src/R2TypeFactory.h
+++ b/src/R2TypeFactory.h
@@ -45,6 +45,7 @@ public:
 	~R2TypeFactory() override;
 
 	Datatype *fromCString(const string &str, string *error = nullptr, std::set<std::string> *stackTypes = nullptr);
+	static std::string toCString(Datatype *type);
 };
 
 #endif //R2GHIDRA_R2TYPEFACTORY_H

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "R2Architecture.h"
-#include "R2TypeFactory.h"
 #include "CodeXMLParse.h"
 #include "PrettyXmlEncode.h"
 #include "R2PrintC.h"
@@ -248,10 +247,8 @@ static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstr
 			func->warningHeader("[r2ghidra] " + warning);
 		}
 	}
-	if (mode == DecompileMode::WRITE) {
-		if (out_harvest) {
-			HarvestFuncdata (arch, func, *out_harvest);
-		}
+	if (out_harvest) {
+		HarvestFuncdata (arch, func, *out_harvest);
 		return;
 	}
 	switch (mode) {

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "R2Architecture.h"
+#include "R2TypeFactory.h"
 #include "CodeXMLParse.h"
 #include "PrettyXmlEncode.h"
 #include "R2PrintC.h"
@@ -81,6 +82,8 @@ CV cfg_var_varargs    ("varargs",     "false",    "Recover printf-family varargs
 CV cfg_var_roprop     ("roprop",      "0",        "Propagate read-only constants (0,1,2,3,4)");
 CV cfg_var_timeout    ("timeout",     "0",        "Run decompilation in a separate process and kill it after a specific time");
 CV cfg_var_compiler   ("compiler",    "default",  "Select compiler for calling conventions", ConfigCompiler);
+CV cfg_var_apply_vars ("apply.vars",  "true",     "pdgw: apply recovered variable names and types");
+CV cfg_var_apply_sig  ("apply.sig",   "true",     "pdgw: apply the recovered function signature");
 
 
 static std::recursive_mutex decompiler_mutex;
@@ -114,6 +117,7 @@ static const char* r2ghidra_help[] = {
 	"pd:gs", "", "# Display loaded Sleigh Languages (alias for pdgL)",
 	"pd:gsd", " N", "# Disassemble N instructions with Sleigh and print pcode",
 	"pd:gss", "", "# Display automatically matched Sleigh Language ID",
+	"pd:gw", "", "# Decompile and apply recovered names, types and signature into r2",
 	"pd:gx", "", "# Dump the XML of the current decompiled function",
 	"Environment:", "", "",
 	"%SLEIGHHOME" , "", "# Path to ghidra sleigh directory (same as r2ghidra.sleighhome)",
@@ -130,7 +134,8 @@ enum class DecompileMode {
 	OFFSET,
 	STATEMENTS,
 	DISASM,
-	JSON
+	JSON,
+	APPLY
 };
 
 static void ApplyPrintCConfig(RConfig *cfg, PrintC *print_c) {
@@ -185,7 +190,279 @@ static void seedGlobalPointerRegister(R2Architecture &arch, RCore *core, RAnalFu
 	});
 }
 
-static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstream &out_stream, RCodeMeta **out_code) {
+struct HarvestVar {
+	std::string name;
+	std::string type; // "" = don't retype
+	std::string regName; // non-empty = register storage
+	std::string regNameFull; // full-width register at the same offset (r2 vars live on the wide name)
+	uintb stackOff = 0;
+	bool onStack = false;
+	bool nameDefined = false;
+};
+
+struct HarvestProto {
+	bool valid = false;
+	std::string retType; // "" = keep the current return type
+	bool dotdotdot = false;
+	bool noreturn = false;
+	std::vector<HarvestVar> params;
+};
+
+struct Harvest {
+	HarvestProto proto;
+	std::vector<HarvestVar> locals;
+	int4 extraPop = 0;
+	uintb stackHighest = 0;
+};
+
+// formalized parameters and promoted locals keep their auto names without the undefined flag
+static bool IsGhidraAutoName(const std::string &name) {
+	size_t pos;
+	if (name.compare (0, strlen ("param_"), "param_") == 0) {
+		pos = strlen ("param_");
+	} else if (name.compare (0, strlen ("local_"), "local_") == 0) {
+		pos = strlen ("local_");
+	} else {
+		return false;
+	}
+	return pos < name.size () && name.find_first_not_of ("0123456789abcdef", pos) == std::string::npos;
+}
+
+static void HarvestStorage(R2Architecture &arch, const Address &a, int4 size, int4 defaultSize, HarvestVar &out) {
+	if (a.isInvalid ()) {
+		return;
+	}
+	if (a.getSpace () == arch.getStackSpace ()) {
+		out.onStack = true;
+		out.stackOff = a.getOffset ();
+		return;
+	}
+	out.regName = arch.registerNameFromAddress (a, size);
+	if (out.regName.empty () && arch.translate->isBigEndian () && size > 0 && size < defaultSize) {
+		// undo the BE low-order placement of sub-width register args
+		out.regName = arch.registerNameFromAddress (Address (a.getSpace (), a.getOffset () - (defaultSize - size)), defaultSize);
+	}
+	if (size > 0 && size < defaultSize) {
+		out.regNameFull = arch.registerNameFromAddress (a, defaultSize);
+	}
+}
+
+// copy the recovered prototype and locals into plain data so nothing references the arch after teardown
+static void HarvestFuncdata(R2Architecture &arch, Funcdata *func, Harvest &out) {
+	const int4 defaultSize = arch.translate->getDefaultSize ();
+	out.stackHighest = arch.getStackSpace ()->getHighest ();
+	FuncProto &proto = func->getFuncProto ();
+	out.extraPop = proto.getExtraPop ();
+	if (out.extraPop == ProtoModel::extrapop_unknown) {
+		out.extraPop = defaultSize;
+	}
+	out.proto.valid = true;
+	out.proto.dotdotdot = proto.isDotdotdot ();
+	out.proto.noreturn = proto.isNoReturn ();
+	out.proto.retType = R2TypeFactory::toCString (proto.getOutputType ());
+	for (int4 i = 0; i < proto.numParams (); i++) {
+		ProtoParameter *param = proto.getParam (i);
+		if (!param || param->isHiddenReturn ()) {
+			continue;
+		}
+		HarvestVar hv;
+		if (!param->isNameUndefined () && !IsGhidraAutoName (param->getName ())) {
+			hv.name = param->getName ();
+			hv.nameDefined = true;
+		}
+		hv.type = R2TypeFactory::toCString (param->getType ());
+		HarvestStorage (arch, param->getAddress (), param->getSize (), defaultSize, hv);
+		out.proto.params.push_back (hv);
+	}
+	ScopeLocal *scope = func->getScopeLocal ();
+	if (!scope) {
+		return;
+	}
+	for (MapIterator it = scope->begin (); it != scope->end (); ++it) {
+		const SymbolEntry *entry = *it;
+		if (!entry || entry->isPiece ()) {
+			continue;
+		}
+		Symbol *sym = entry->getSymbol ();
+		if (!sym || sym->getName ().empty () || sym->getCategory () != Symbol::no_category) {
+			continue;
+		}
+		if (dynamic_cast<FunctionSymbol *> (sym) || dynamic_cast<LabSymbol *> (sym)) {
+			continue;
+		}
+		HarvestVar hv;
+		if (!sym->isNameUndefined () && !IsGhidraAutoName (sym->getName ())) {
+			hv.name = sym->getName ();
+			hv.nameDefined = true;
+		}
+		hv.type = R2TypeFactory::toCString (sym->getType ());
+		HarvestStorage (arch, entry->getAddr (), entry->getSize (), defaultSize, hv);
+		if ((!hv.onStack && hv.regName.empty () && hv.regNameFull.empty ()) || (hv.type.empty () && !hv.nameDefined)) {
+			continue;
+		}
+		out.locals.push_back (hv);
+	}
+}
+
+static bool TypeParseable(RAnal *anal, const std::string &type) {
+	std::string base = type;
+	while (!base.empty () && (base.back () == '*' || base.back () == ' ')) {
+		base.pop_back ();
+	}
+	if (base.empty ()) {
+		return false;
+	}
+	if (base == "void") {
+		return true;
+	}
+	return r_type_kind (anal->sdb_types, base.c_str ()) != R_TYPE_INVALID;
+}
+
+static RAnalVar *MatchRegVar(RCore *core, RAnalFunction *fcn, const std::string &regName) {
+	if (regName.empty ()) {
+		return nullptr;
+	}
+	RRegItem *ri = r_reg_get (core->anal->reg, regName.c_str (), -1);
+	if (!ri) {
+		return nullptr;
+	}
+	const int index = ri->index;
+	r_unref (ri);
+	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_REG, index);
+}
+
+static RAnalVar *MatchVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h) {
+	if (!hv.regName.empty () || !hv.regNameFull.empty ()) {
+		RAnalVar *var = MatchRegVar (core, fcn, hv.regName);
+		return var ? var : MatchRegVar (core, fcn, hv.regNameFull);
+	}
+	if (!hv.onStack) {
+		return nullptr;
+	}
+	// invert the stack mapping from FunctionVars::addr: negative deltas wrap to the top of the stack space
+	st64 gdelta = (hv.stackOff > h.stackHighest / 2)
+		? (st64)hv.stackOff - (st64)h.stackHighest - 1
+		: (st64)hv.stackOff;
+	int delta = (int)(gdelta - fcn->bp_off + h.extraPop);
+	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_BPV, delta);
+}
+
+static void ApplyVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h, int *types, int *names) {
+	RAnalVar *var = MatchVar (core, fcn, hv, h);
+	if (!var) {
+		R_LOG_DEBUG ("pdgw: no r2 variable matches %s", hv.name.c_str ());
+		return;
+	}
+	if (!hv.type.empty () && (!var->type || hv.type != var->type)) {
+		if (TypeParseable (core->anal, hv.type)) {
+			r_anal_var_set_type (core->anal, var, hv.type.c_str ());
+			(*types)++;
+		} else {
+			R_LOG_DEBUG ("pdgw: skipping unknown type %s", hv.type.c_str ());
+		}
+	}
+	if (hv.nameDefined && var->name && hv.name != var->name) {
+		if (r_anal_var_rename (core->anal, var, hv.name.c_str ())) {
+			(*names)++;
+		}
+	}
+}
+
+static void param_free(void *p) {
+	RAnalFunctionParam *fp = (RAnalFunctionParam *)p;
+	if (fp) {
+		free (fp->name);
+		free (fp->type);
+		free (fp);
+	}
+}
+
+static bool ApplySignature(RCore *core, RAnalFunction *fcn, const Harvest &h) {
+	RAnalFunctionSignature *cur = r_anal_function_get_signature (fcn);
+	const char *curRet = (cur && R_STR_ISNOTEMPTY (cur->ret_type)) ? cur->ret_type : NULL;
+	std::string ret = h.proto.retType;
+	if (ret.empty () || !TypeParseable (core->anal, ret)) {
+		ret = curRet ? curRet : "void";
+	} else if (ret == "void" && curRet && strcmp (curRet, "void")) {
+		// the decompiler demotes unused return values to void; never lose a known return type
+		ret = curRet;
+	}
+	RAnalFunctionSignature sig = {};
+	sig.ret_type = (char *)ret.c_str ();
+	sig.callconv = (char *)fcn->callconv;
+	sig.noreturn = h.proto.noreturn || fcn->is_noreturn;
+	sig.params = r_list_newf (param_free);
+	bool complete = true;
+	int idx = 0;
+	for (const HarvestVar &hv : h.proto.params) {
+		if (hv.type.empty () || !TypeParseable (core->anal, hv.type)) {
+			complete = false;
+			break;
+		}
+		RAnalFunctionParam *fp = R_NEW0 (RAnalFunctionParam);
+		std::string pname = hv.name;
+		if (!hv.nameDefined) {
+			RAnalVar *var = MatchVar (core, fcn, hv, h);
+			pname = (var && var->name) ? var->name : "arg" + std::to_string (idx + 1);
+		}
+		fp->name = strdup (pname.c_str ());
+		fp->type = strdup (hv.type.c_str ());
+		r_list_append (sig.params, fp);
+		idx++;
+	}
+	if (complete && h.proto.dotdotdot) {
+		RAnalFunctionParam *fp = R_NEW0 (RAnalFunctionParam);
+		fp->type = strdup ("...");
+		r_list_append (sig.params, fp);
+	}
+	bool changed = !cur;
+	if (complete && cur) {
+		changed = !cur->ret_type || ret != cur->ret_type
+			|| r_list_length (cur->params) != r_list_length (sig.params);
+		for (ut32 i = 0; !changed && i < r_list_length (sig.params); i++) {
+			RAnalFunctionParam *pa = (RAnalFunctionParam *)r_list_get_n (cur->params, i);
+			RAnalFunctionParam *pb = (RAnalFunctionParam *)r_list_get_n (sig.params, i);
+			if (strcmp (r_str_get (pa->type), r_str_get (pb->type)) || strcmp (r_str_get (pa->name), r_str_get (pb->name))) {
+				changed = true;
+			}
+		}
+	}
+	bool applied = false;
+	if (complete && changed) {
+		applied = r_anal_function_set_signature (core->anal, fcn, &sig);
+		if (!applied) {
+			R_LOG_DEBUG ("pdgw: signature rejected by the type parser");
+		}
+	} else if (!complete) {
+		R_LOG_DEBUG ("pdgw: incomplete parameter types, not applying the signature");
+	}
+	r_list_free (sig.params);
+	r_anal_function_signature_free (cur);
+	return applied;
+}
+
+static void ApplyHarvest(RCore *core, RAnalFunction *fcn, const Harvest &h) {
+	int types = 0, names = 0;
+	bool sig = false;
+	if (cfg_var_apply_vars.GetBool (core->config)) {
+		for (const HarvestVar &hv : h.proto.params) {
+			ApplyVar (core, fcn, hv, h, &types, &names);
+		}
+		for (const HarvestVar &hv : h.locals) {
+			ApplyVar (core, fcn, hv, h, &types, &names);
+		}
+	}
+	if (cfg_var_apply_sig.GetBool (core->config) && h.proto.valid) {
+		sig = ApplySignature (core, fcn, h);
+	}
+	if (types || names || sig) {
+		r_cons_printf (core->cons, "pdgw: applied %d types, %d names%s\n", types, names, sig ? ", signature" : "");
+	} else {
+		r_cons_printf (core->cons, "pdgw: no changes\n");
+	}
+}
+
+static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstream &out_stream, RCodeMeta **out_code, Harvest *out_harvest = nullptr) {
 	RAnalFunction *function = r_anal_get_fcn_in (core->anal, addr, R_ANAL_FCN_TYPE_NULL);
 	if (!function) {
 		throw LowlevelError ("No function at this offset");
@@ -241,6 +518,12 @@ static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstr
 		for (const auto &warning : arch.getWarnings()) {
 			func->warningHeader("[r2ghidra] " + warning);
 		}
+	}
+	if (mode == DecompileMode::APPLY) {
+		if (out_harvest) {
+			HarvestFuncdata (arch, func, *out_harvest);
+		}
+		return;
 	}
 	switch (mode) {
 	case DecompileMode::XML:
@@ -320,8 +603,17 @@ static void DecompileCmd (RCore *core, DecompileMode mode) {
 #endif
 		RCodeMeta *code = nullptr;
 		std::stringstream out_stream;
-		Decompile (core, core->addr, mode, out_stream, &code);
+		Harvest harvest;
+		Decompile (core, core->addr, mode, out_stream, &code, mode == DecompileMode::APPLY ? &harvest : nullptr);
 		switch (mode) {
+		case DecompileMode::APPLY:
+			{
+				RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->addr, R_ANAL_FCN_TYPE_NULL);
+				if (fcn) {
+					ApplyHarvest (core, fcn, harvest);
+				}
+			}
+			break;
 		case DecompileMode::DISASM:
 			{
 #if defined(R2_ABIVERSION) && R2_ABIVERSION >= 40
@@ -617,6 +909,9 @@ static void runcmd(RCore *core, const char *input) {
 	case 'a': // "pdga"
 		DecompileCmd (core, DecompileMode::DISASM);
 		break;
+	case 'w': // "pdgw"
+		DecompileCmd (core, DecompileMode::APPLY);
+		break;
 	case 'p': // "pdgp"
 		EnablePlugin (core);
 		break;
@@ -628,6 +923,11 @@ static void runcmd(RCore *core, const char *input) {
 
 static void _cmd(RCore *core, const char *input) {
 	int timeout = r_config_get_i (core->config, "r2ghidra.timeout");
+	if (*input == 'w') {
+		// pdgw writes into the r2 DB; a forked child would lose the writes
+		runcmd (core, input);
+		return;
+	}
 	if (timeout > 0) {
 #if R2__UNIX__
 		// TODO: note that first execution is slower than the rest. and forking loses the cache

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <vector>
+#include <set>
 #include <mutex>
 
 #undef DEBUG_EXCEPTIONS
@@ -215,17 +216,38 @@ struct Harvest {
 	uintb stackHighest = 0;
 };
 
-// formalized parameters and promoted locals keep their auto names without the undefined flag
-static bool IsGhidraAutoName(const std::string &name) {
-	size_t pos;
-	if (name.compare (0, strlen ("param_"), "param_") == 0) {
-		pos = strlen ("param_");
-	} else if (name.compare (0, strlen ("local_"), "local_") == 0) {
-		pos = strlen ("local_");
-	} else {
-		return false;
-	}
+static bool IsGhidraAutoSuffix(const std::string &name, size_t pos) {
 	return pos < name.size () && name.find_first_not_of ("0123456789abcdef", pos) == std::string::npos;
+}
+
+// generated names are not flagged undefined; match every ScopeInternal::buildVariableName pattern
+static bool IsGhidraAutoName(const std::string &name) {
+	if (name.compare (0, strlen ("in_"), "in_") == 0
+			|| name.compare (0, strlen ("unaff_"), "unaff_") == 0
+			|| name.compare (0, strlen ("extraout_"), "extraout_") == 0) {
+		return true;
+	}
+	if (name.compare (0, strlen ("param_"), "param_") == 0) {
+		return IsGhidraAutoSuffix (name, strlen ("param_"));
+	}
+	if (name.compare (0, strlen ("local_"), "local_") == 0) {
+		return IsGhidraAutoSuffix (name, strlen ("local_"));
+	}
+	// type-prefixed forms like iVar1, puVar2, auStack_28, iStack_10
+	for (const char *marker : { "Var", "Stack" }) {
+		size_t m = name.find (marker);
+		if (m == std::string::npos || name.find_first_not_of ("abcdefghijklmnopqrstuvwxyz") != m) {
+			continue;
+		}
+		size_t pos = m + strlen (marker);
+		if (pos < name.size () && name[pos] == '_') {
+			pos++;
+		}
+		if (IsGhidraAutoSuffix (name, pos)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 static void HarvestStorage(R2Architecture &arch, const Address &a, int4 size, int4 defaultSize, HarvestVar &out) {
@@ -347,10 +369,14 @@ static RAnalVar *MatchVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv,
 	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_BPV, delta);
 }
 
-static void ApplyVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h, int *types, int *names) {
+static void ApplyVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h, std::set<RAnalVar *> &seen, int *types, int *names) {
 	RAnalVar *var = MatchVar (core, fcn, hv, h);
 	if (!var) {
 		R_LOG_DEBUG ("pdgw: no r2 variable matches %s", hv.name.c_str ());
+		return;
+	}
+	// params and locals can share storage; the first (param) view wins
+	if (!seen.insert (var).second) {
 		return;
 	}
 	if (!hv.type.empty () && (!var->type || hv.type != var->type)) {
@@ -419,7 +445,7 @@ static bool ApplySignature(RCore *core, RAnalFunction *fcn, const Harvest &h) {
 	if (complete && cur) {
 		changed = !cur->ret_type || ret != cur->ret_type
 			|| r_list_length (cur->params) != r_list_length (sig.params);
-		for (ut32 i = 0; !changed && i < r_list_length (sig.params); i++) {
+		for (int i = 0; !changed && i < r_list_length (sig.params); i++) {
 			RAnalFunctionParam *pa = (RAnalFunctionParam *)r_list_get_n (cur->params, i);
 			RAnalFunctionParam *pb = (RAnalFunctionParam *)r_list_get_n (sig.params, i);
 			if (strcmp (r_str_get (pa->type), r_str_get (pb->type)) || strcmp (r_str_get (pa->name), r_str_get (pb->name))) {
@@ -445,11 +471,12 @@ static void ApplyHarvest(RCore *core, RAnalFunction *fcn, const Harvest &h) {
 	int types = 0, names = 0;
 	bool sig = false;
 	if (cfg_var_apply_vars.GetBool (core->config)) {
+		std::set<RAnalVar *> seen;
 		for (const HarvestVar &hv : h.proto.params) {
-			ApplyVar (core, fcn, hv, h, &types, &names);
+			ApplyVar (core, fcn, hv, h, seen, &types, &names);
 		}
 		for (const HarvestVar &hv : h.locals) {
-			ApplyVar (core, fcn, hv, h, &types, &names);
+			ApplyVar (core, fcn, hv, h, seen, &types, &names);
 		}
 	}
 	if (cfg_var_apply_sig.GetBool (core->config) && h.proto.valid) {

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -10,6 +10,7 @@
 #include "ArchMap.h"
 #include "PcodeFixupPreprocessor.h"
 #include "R2Utils.h"
+#include "r2harvest.h"
 #include "r2ghidra.h"
 #include <r_core.h>
 
@@ -26,7 +27,6 @@
 #endif
 
 #include <vector>
-#include <set>
 #include <mutex>
 
 #undef DEBUG_EXCEPTIONS
@@ -83,8 +83,8 @@ CV cfg_var_varargs    ("varargs",     "false",    "Recover printf-family varargs
 CV cfg_var_roprop     ("roprop",      "0",        "Propagate read-only constants (0,1,2,3,4)");
 CV cfg_var_timeout    ("timeout",     "0",        "Run decompilation in a separate process and kill it after a specific time");
 CV cfg_var_compiler   ("compiler",    "default",  "Select compiler for calling conventions", ConfigCompiler);
-CV cfg_var_apply_vars ("apply.vars",  "true",     "pdgw: apply recovered variable names and types");
-CV cfg_var_apply_sig  ("apply.sig",   "true",     "pdgw: apply the recovered function signature");
+CV cfg_var_write_vars ("write.vars",  "true",     "pdgw: write recovered variable names and types");
+CV cfg_var_write_sig  ("write.sig",   "true",     "pdgw: write the recovered function signature");
 
 
 static std::recursive_mutex decompiler_mutex;
@@ -118,7 +118,7 @@ static const char* r2ghidra_help[] = {
 	"pd:gs", "", "# Display loaded Sleigh Languages (alias for pdgL)",
 	"pd:gsd", " N", "# Disassemble N instructions with Sleigh and print pcode",
 	"pd:gss", "", "# Display automatically matched Sleigh Language ID",
-	"pd:gw", "", "# Decompile and apply recovered names, types and signature into r2",
+	"pd:gw", "", "# Decompile and write recovered names, types and signature back into r2",
 	"pd:gx", "", "# Dump the XML of the current decompiled function",
 	"Environment:", "", "",
 	"%SLEIGHHOME" , "", "# Path to ghidra sleigh directory (same as r2ghidra.sleighhome)",
@@ -136,7 +136,7 @@ enum class DecompileMode {
 	STATEMENTS,
 	DISASM,
 	JSON,
-	APPLY
+	WRITE
 };
 
 static void ApplyPrintCConfig(RConfig *cfg, PrintC *print_c) {
@@ -189,304 +189,6 @@ static void seedGlobalPointerRegister(R2Architecture &arch, RCore *core, RAnalFu
 		TrackedSet &tset = cdb->createSet (Address (space, bb->addr), Address (space, bb->addr + bb->size));
 		tset.push_back ({ reg, value });
 	});
-}
-
-struct HarvestVar {
-	std::string name;
-	std::string type; // "" = don't retype
-	std::string regName; // non-empty = register storage
-	std::string regNameFull; // full-width register at the same offset (r2 vars live on the wide name)
-	uintb stackOff = 0;
-	bool onStack = false;
-	bool nameDefined = false;
-};
-
-struct HarvestProto {
-	bool valid = false;
-	std::string retType; // "" = keep the current return type
-	bool dotdotdot = false;
-	bool noreturn = false;
-	std::vector<HarvestVar> params;
-};
-
-struct Harvest {
-	HarvestProto proto;
-	std::vector<HarvestVar> locals;
-	int4 extraPop = 0;
-	uintb stackHighest = 0;
-};
-
-static bool IsGhidraAutoSuffix(const std::string &name, size_t pos) {
-	return pos < name.size () && name.find_first_not_of ("0123456789abcdef", pos) == std::string::npos;
-}
-
-// generated names are not flagged undefined; match every ScopeInternal::buildVariableName pattern
-static bool IsGhidraAutoName(const std::string &name) {
-	if (name.compare (0, strlen ("in_"), "in_") == 0
-			|| name.compare (0, strlen ("unaff_"), "unaff_") == 0
-			|| name.compare (0, strlen ("extraout_"), "extraout_") == 0) {
-		return true;
-	}
-	if (name.compare (0, strlen ("param_"), "param_") == 0) {
-		return IsGhidraAutoSuffix (name, strlen ("param_"));
-	}
-	if (name.compare (0, strlen ("local_"), "local_") == 0) {
-		return IsGhidraAutoSuffix (name, strlen ("local_"));
-	}
-	// type-prefixed forms like iVar1, puVar2, auStack_28, iStack_10
-	for (const char *marker : { "Var", "Stack" }) {
-		size_t m = name.find (marker);
-		if (m == std::string::npos || name.find_first_not_of ("abcdefghijklmnopqrstuvwxyz") != m) {
-			continue;
-		}
-		size_t pos = m + strlen (marker);
-		if (pos < name.size () && name[pos] == '_') {
-			pos++;
-		}
-		if (IsGhidraAutoSuffix (name, pos)) {
-			return true;
-		}
-	}
-	return false;
-}
-
-static void HarvestStorage(R2Architecture &arch, const Address &a, int4 size, int4 defaultSize, HarvestVar &out) {
-	if (a.isInvalid ()) {
-		return;
-	}
-	if (a.getSpace () == arch.getStackSpace ()) {
-		out.onStack = true;
-		out.stackOff = a.getOffset ();
-		return;
-	}
-	out.regName = arch.registerNameFromAddress (a, size);
-	if (out.regName.empty () && arch.translate->isBigEndian () && size > 0 && size < defaultSize) {
-		// undo the BE low-order placement of sub-width register args
-		out.regName = arch.registerNameFromAddress (Address (a.getSpace (), a.getOffset () - (defaultSize - size)), defaultSize);
-	}
-	if (size > 0 && size < defaultSize) {
-		out.regNameFull = arch.registerNameFromAddress (a, defaultSize);
-	}
-}
-
-// copy the recovered prototype and locals into plain data so nothing references the arch after teardown
-static void HarvestFuncdata(R2Architecture &arch, Funcdata *func, Harvest &out) {
-	const int4 defaultSize = arch.translate->getDefaultSize ();
-	out.stackHighest = arch.getStackSpace ()->getHighest ();
-	FuncProto &proto = func->getFuncProto ();
-	out.extraPop = proto.getExtraPop ();
-	if (out.extraPop == ProtoModel::extrapop_unknown) {
-		out.extraPop = defaultSize;
-	}
-	out.proto.valid = true;
-	out.proto.dotdotdot = proto.isDotdotdot ();
-	out.proto.noreturn = proto.isNoReturn ();
-	out.proto.retType = R2TypeFactory::toCString (proto.getOutputType ());
-	for (int4 i = 0; i < proto.numParams (); i++) {
-		ProtoParameter *param = proto.getParam (i);
-		if (!param || param->isHiddenReturn ()) {
-			continue;
-		}
-		HarvestVar hv;
-		if (!param->isNameUndefined () && !IsGhidraAutoName (param->getName ())) {
-			hv.name = param->getName ();
-			hv.nameDefined = true;
-		}
-		hv.type = R2TypeFactory::toCString (param->getType ());
-		HarvestStorage (arch, param->getAddress (), param->getSize (), defaultSize, hv);
-		out.proto.params.push_back (hv);
-	}
-	ScopeLocal *scope = func->getScopeLocal ();
-	if (!scope) {
-		return;
-	}
-	for (MapIterator it = scope->begin (); it != scope->end (); ++it) {
-		const SymbolEntry *entry = *it;
-		if (!entry || entry->isPiece ()) {
-			continue;
-		}
-		Symbol *sym = entry->getSymbol ();
-		if (!sym || sym->getName ().empty () || sym->getCategory () != Symbol::no_category) {
-			continue;
-		}
-		if (dynamic_cast<FunctionSymbol *> (sym) || dynamic_cast<LabSymbol *> (sym)) {
-			continue;
-		}
-		HarvestVar hv;
-		if (!sym->isNameUndefined () && !IsGhidraAutoName (sym->getName ())) {
-			hv.name = sym->getName ();
-			hv.nameDefined = true;
-		}
-		hv.type = R2TypeFactory::toCString (sym->getType ());
-		HarvestStorage (arch, entry->getAddr (), entry->getSize (), defaultSize, hv);
-		if ((!hv.onStack && hv.regName.empty () && hv.regNameFull.empty ()) || (hv.type.empty () && !hv.nameDefined)) {
-			continue;
-		}
-		out.locals.push_back (hv);
-	}
-}
-
-static bool TypeParseable(RAnal *anal, const std::string &type) {
-	std::string base = type;
-	while (!base.empty () && (base.back () == '*' || base.back () == ' ')) {
-		base.pop_back ();
-	}
-	if (base.empty ()) {
-		return false;
-	}
-	if (base == "void") {
-		return true;
-	}
-	return r_type_kind (anal->sdb_types, base.c_str ()) != R_TYPE_INVALID;
-}
-
-static RAnalVar *MatchRegVar(RCore *core, RAnalFunction *fcn, const std::string &regName) {
-	if (regName.empty ()) {
-		return nullptr;
-	}
-	RRegItem *ri = r_reg_get (core->anal->reg, regName.c_str (), -1);
-	if (!ri) {
-		return nullptr;
-	}
-	const int index = ri->index;
-	r_unref (ri);
-	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_REG, index);
-}
-
-static RAnalVar *MatchVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h) {
-	if (!hv.regName.empty () || !hv.regNameFull.empty ()) {
-		RAnalVar *var = MatchRegVar (core, fcn, hv.regName);
-		return var ? var : MatchRegVar (core, fcn, hv.regNameFull);
-	}
-	if (!hv.onStack) {
-		return nullptr;
-	}
-	// invert the stack mapping from FunctionVars::addr: negative deltas wrap to the top of the stack space
-	st64 gdelta = (hv.stackOff > h.stackHighest / 2)
-		? (st64)hv.stackOff - (st64)h.stackHighest - 1
-		: (st64)hv.stackOff;
-	int delta = (int)(gdelta - fcn->bp_off + h.extraPop);
-	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_BPV, delta);
-}
-
-static void ApplyVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h, std::set<RAnalVar *> &seen, int *types, int *names) {
-	RAnalVar *var = MatchVar (core, fcn, hv, h);
-	if (!var) {
-		R_LOG_DEBUG ("pdgw: no r2 variable matches %s", hv.name.c_str ());
-		return;
-	}
-	// params and locals can share storage; the first (param) view wins
-	if (!seen.insert (var).second) {
-		return;
-	}
-	if (!hv.type.empty () && (!var->type || hv.type != var->type)) {
-		if (TypeParseable (core->anal, hv.type)) {
-			r_anal_var_set_type (core->anal, var, hv.type.c_str ());
-			(*types)++;
-		} else {
-			R_LOG_DEBUG ("pdgw: skipping unknown type %s", hv.type.c_str ());
-		}
-	}
-	if (hv.nameDefined && var->name && hv.name != var->name) {
-		if (r_anal_var_rename (core->anal, var, hv.name.c_str ())) {
-			(*names)++;
-		}
-	}
-}
-
-static void param_free(void *p) {
-	RAnalFunctionParam *fp = (RAnalFunctionParam *)p;
-	if (fp) {
-		free (fp->name);
-		free (fp->type);
-		free (fp);
-	}
-}
-
-static bool ApplySignature(RCore *core, RAnalFunction *fcn, const Harvest &h) {
-	RAnalFunctionSignature *cur = r_anal_function_get_signature (fcn);
-	const char *curRet = (cur && R_STR_ISNOTEMPTY (cur->ret_type)) ? cur->ret_type : NULL;
-	std::string ret = h.proto.retType;
-	if (ret.empty () || !TypeParseable (core->anal, ret)) {
-		ret = curRet ? curRet : "void";
-	} else if (ret == "void" && curRet && strcmp (curRet, "void")) {
-		// the decompiler demotes unused return values to void; never lose a known return type
-		ret = curRet;
-	}
-	RAnalFunctionSignature sig = {};
-	sig.ret_type = (char *)ret.c_str ();
-	sig.callconv = (char *)fcn->callconv;
-	sig.noreturn = h.proto.noreturn || fcn->is_noreturn;
-	sig.params = r_list_newf (param_free);
-	bool complete = true;
-	int idx = 0;
-	for (const HarvestVar &hv : h.proto.params) {
-		if (hv.type.empty () || !TypeParseable (core->anal, hv.type)) {
-			complete = false;
-			break;
-		}
-		RAnalFunctionParam *fp = R_NEW0 (RAnalFunctionParam);
-		std::string pname = hv.name;
-		if (!hv.nameDefined) {
-			RAnalVar *var = MatchVar (core, fcn, hv, h);
-			pname = (var && var->name) ? var->name : "arg" + std::to_string (idx + 1);
-		}
-		fp->name = strdup (pname.c_str ());
-		fp->type = strdup (hv.type.c_str ());
-		r_list_append (sig.params, fp);
-		idx++;
-	}
-	if (complete && h.proto.dotdotdot) {
-		RAnalFunctionParam *fp = R_NEW0 (RAnalFunctionParam);
-		fp->type = strdup ("...");
-		r_list_append (sig.params, fp);
-	}
-	bool changed = !cur;
-	if (complete && cur) {
-		changed = !cur->ret_type || ret != cur->ret_type
-			|| r_list_length (cur->params) != r_list_length (sig.params);
-		for (int i = 0; !changed && i < r_list_length (sig.params); i++) {
-			RAnalFunctionParam *pa = (RAnalFunctionParam *)r_list_get_n (cur->params, i);
-			RAnalFunctionParam *pb = (RAnalFunctionParam *)r_list_get_n (sig.params, i);
-			if (strcmp (r_str_get (pa->type), r_str_get (pb->type)) || strcmp (r_str_get (pa->name), r_str_get (pb->name))) {
-				changed = true;
-			}
-		}
-	}
-	bool applied = false;
-	if (complete && changed) {
-		applied = r_anal_function_set_signature (core->anal, fcn, &sig);
-		if (!applied) {
-			R_LOG_DEBUG ("pdgw: signature rejected by the type parser");
-		}
-	} else if (!complete) {
-		R_LOG_DEBUG ("pdgw: incomplete parameter types, not applying the signature");
-	}
-	r_list_free (sig.params);
-	r_anal_function_signature_free (cur);
-	return applied;
-}
-
-static void ApplyHarvest(RCore *core, RAnalFunction *fcn, const Harvest &h) {
-	int types = 0, names = 0;
-	bool sig = false;
-	if (cfg_var_apply_vars.GetBool (core->config)) {
-		std::set<RAnalVar *> seen;
-		for (const HarvestVar &hv : h.proto.params) {
-			ApplyVar (core, fcn, hv, h, seen, &types, &names);
-		}
-		for (const HarvestVar &hv : h.locals) {
-			ApplyVar (core, fcn, hv, h, seen, &types, &names);
-		}
-	}
-	if (cfg_var_apply_sig.GetBool (core->config) && h.proto.valid) {
-		sig = ApplySignature (core, fcn, h);
-	}
-	if (types || names || sig) {
-		r_cons_printf (core->cons, "pdgw: applied %d types, %d names%s\n", types, names, sig ? ", signature" : "");
-	} else {
-		r_cons_printf (core->cons, "pdgw: no changes\n");
-	}
 }
 
 static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstream &out_stream, RCodeMeta **out_code, Harvest *out_harvest = nullptr) {
@@ -546,7 +248,7 @@ static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstr
 			func->warningHeader("[r2ghidra] " + warning);
 		}
 	}
-	if (mode == DecompileMode::APPLY) {
+	if (mode == DecompileMode::WRITE) {
 		if (out_harvest) {
 			HarvestFuncdata (arch, func, *out_harvest);
 		}
@@ -631,13 +333,13 @@ static void DecompileCmd (RCore *core, DecompileMode mode) {
 		RCodeMeta *code = nullptr;
 		std::stringstream out_stream;
 		Harvest harvest;
-		Decompile (core, core->addr, mode, out_stream, &code, mode == DecompileMode::APPLY ? &harvest : nullptr);
+		Decompile (core, core->addr, mode, out_stream, &code, mode == DecompileMode::WRITE ? &harvest : nullptr);
 		switch (mode) {
-		case DecompileMode::APPLY:
+		case DecompileMode::WRITE:
 			{
 				RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->addr, R_ANAL_FCN_TYPE_NULL);
 				if (fcn) {
-					ApplyHarvest (core, fcn, harvest);
+					WriteHarvest (core, fcn, harvest, cfg_var_write_vars.GetBool (core->config), cfg_var_write_sig.GetBool (core->config));
 				}
 			}
 			break;
@@ -937,7 +639,7 @@ static void runcmd(RCore *core, const char *input) {
 		DecompileCmd (core, DecompileMode::DISASM);
 		break;
 	case 'w': // "pdgw"
-		DecompileCmd (core, DecompileMode::APPLY);
+		DecompileCmd (core, DecompileMode::WRITE);
 		break;
 	case 'p': // "pdgp"
 		EnablePlugin (core);

--- a/src/r2harvest.cpp
+++ b/src/r2harvest.cpp
@@ -24,8 +24,9 @@ static bool IsGhidraAutoName(const std::string &name) {
 		{ "local_", true }
 	};
 	for (const auto &p : prefixes) {
-		if (name.compare (0, strlen (p.prefix), p.prefix) == 0) {
-			return !p.hexSuffix || IsGhidraAutoSuffix (name, strlen (p.prefix));
+		const size_t n = strlen (p.prefix);
+		if (name.compare (0, n, p.prefix) == 0) {
+			return !p.hexSuffix || IsGhidraAutoSuffix (name, n);
 		}
 	}
 	// type-prefixed forms like iVar1, puVar2, auStack_28, iStack_10
@@ -127,17 +128,12 @@ void HarvestFuncdata(R2Architecture &arch, Funcdata *func, Harvest &out) {
 }
 
 static bool TypeParseable(RAnal *anal, const std::string &type) {
-	std::string base = type;
-	while (!base.empty () && (base.back () == '*' || base.back () == ' ')) {
-		base.pop_back ();
-	}
-	if (base.empty ()) {
+	const size_t end = type.find_last_not_of ("* ");
+	if (end == std::string::npos) {
 		return false;
 	}
-	if (base == "void") {
-		return true;
-	}
-	return r_type_kind (anal->sdb_types, base.c_str ()) != R_TYPE_INVALID;
+	const std::string base = type.substr (0, end + 1);
+	return base == "void" || r_type_kind (anal->sdb_types, base.c_str ()) != R_TYPE_INVALID;
 }
 
 static RAnalVar *MatchRegVar(RCore *core, RAnalFunction *fcn, const std::string &regName) {

--- a/src/r2harvest.cpp
+++ b/src/r2harvest.cpp
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: 2026 pancake
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "r2harvest.h"
+#include "R2TypeFactory.h"
+
+#include <funcdata.hh>
+#include <fspec.hh>
+#include <database.hh>
+
+#include <set>
+
+static bool IsGhidraAutoSuffix(const std::string &name, size_t pos) {
+	return pos < name.size () && name.find_first_not_of ("0123456789abcdef", pos) == std::string::npos;
+}
+
+// generated names are not flagged undefined; match every ScopeInternal::buildVariableName pattern
+static bool IsGhidraAutoName(const std::string &name) {
+	static const struct { const char *prefix; bool hexSuffix; } prefixes[] = {
+		{ "in_", false },
+		{ "unaff_", false },
+		{ "extraout_", false },
+		{ "param_", true },
+		{ "local_", true }
+	};
+	for (const auto &p : prefixes) {
+		if (name.compare (0, strlen (p.prefix), p.prefix) == 0) {
+			return !p.hexSuffix || IsGhidraAutoSuffix (name, strlen (p.prefix));
+		}
+	}
+	// type-prefixed forms like iVar1, puVar2, auStack_28, iStack_10
+	for (const char *marker : { "Var", "Stack" }) {
+		size_t m = name.find (marker);
+		if (m == std::string::npos || name.find_first_not_of ("abcdefghijklmnopqrstuvwxyz") != m) {
+			continue;
+		}
+		size_t pos = m + strlen (marker);
+		if (pos < name.size () && name[pos] == '_') {
+			pos++;
+		}
+		if (IsGhidraAutoSuffix (name, pos)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void HarvestStorage(R2Architecture &arch, const Address &a, int4 size, int4 defaultSize, HarvestVar &out) {
+	if (a.isInvalid ()) {
+		return;
+	}
+	if (a.getSpace () == arch.getStackSpace ()) {
+		out.onStack = true;
+		out.stackOff = a.getOffset ();
+		return;
+	}
+	std::string reg = arch.registerNameFromAddress (a, size);
+	if (reg.empty () && arch.translate->isBigEndian () && size > 0 && size < defaultSize) {
+		// undo the BE low-order placement of sub-width register args
+		reg = arch.registerNameFromAddress (Address (a.getSpace (), a.getOffset () - (defaultSize - size)), defaultSize);
+	}
+	if (!reg.empty ()) {
+		out.regNames.push_back (reg);
+	}
+	if (size > 0 && size < defaultSize) {
+		// r2 vars live on the full-width register name
+		std::string full = arch.registerNameFromAddress (a, defaultSize);
+		if (!full.empty () && full != reg) {
+			out.regNames.push_back (full);
+		}
+	}
+}
+
+static void FillHarvestVar(R2Architecture &arch, const std::string &name, bool nameUndefined, Datatype *type, const Address &addr, int4 size, int4 defaultSize, HarvestVar &out) {
+	if (!nameUndefined && !IsGhidraAutoName (name)) {
+		out.name = name;
+		out.nameDefined = true;
+	}
+	out.type = R2TypeFactory::toCString (type);
+	HarvestStorage (arch, addr, size, defaultSize, out);
+}
+
+void HarvestFuncdata(R2Architecture &arch, Funcdata *func, Harvest &out) {
+	const int4 defaultSize = arch.translate->getDefaultSize ();
+	out.stackHighest = arch.getStackSpace ()->getHighest ();
+	FuncProto &proto = func->getFuncProto ();
+	out.extraPop = proto.getExtraPop ();
+	if (out.extraPop == ProtoModel::extrapop_unknown) {
+		out.extraPop = defaultSize;
+	}
+	out.proto.valid = true;
+	out.proto.dotdotdot = proto.isDotdotdot ();
+	out.proto.noreturn = proto.isNoReturn ();
+	out.proto.retType = R2TypeFactory::toCString (proto.getOutputType ());
+	for (int4 i = 0; i < proto.numParams (); i++) {
+		ProtoParameter *param = proto.getParam (i);
+		if (!param || param->isHiddenReturn ()) {
+			continue;
+		}
+		HarvestVar hv;
+		FillHarvestVar (arch, param->getName (), param->isNameUndefined (), param->getType (), param->getAddress (), param->getSize (), defaultSize, hv);
+		out.proto.params.push_back (hv);
+	}
+	ScopeLocal *scope = func->getScopeLocal ();
+	if (!scope) {
+		return;
+	}
+	for (MapIterator it = scope->begin (); it != scope->end (); ++it) {
+		const SymbolEntry *entry = *it;
+		if (!entry || entry->isPiece ()) {
+			continue;
+		}
+		Symbol *sym = entry->getSymbol ();
+		if (!sym || sym->getName ().empty () || sym->getCategory () != Symbol::no_category) {
+			continue;
+		}
+		if (dynamic_cast<FunctionSymbol *> (sym) || dynamic_cast<LabSymbol *> (sym)) {
+			continue;
+		}
+		HarvestVar hv;
+		FillHarvestVar (arch, sym->getName (), sym->isNameUndefined (), sym->getType (), entry->getAddr (), entry->getSize (), defaultSize, hv);
+		if ((!hv.onStack && hv.regNames.empty ()) || (hv.type.empty () && !hv.nameDefined)) {
+			continue;
+		}
+		out.locals.push_back (hv);
+	}
+}
+
+static bool TypeParseable(RAnal *anal, const std::string &type) {
+	std::string base = type;
+	while (!base.empty () && (base.back () == '*' || base.back () == ' ')) {
+		base.pop_back ();
+	}
+	if (base.empty ()) {
+		return false;
+	}
+	if (base == "void") {
+		return true;
+	}
+	return r_type_kind (anal->sdb_types, base.c_str ()) != R_TYPE_INVALID;
+}
+
+static RAnalVar *MatchRegVar(RCore *core, RAnalFunction *fcn, const std::string &regName) {
+	RRegItem *ri = r_reg_get (core->anal->reg, regName.c_str (), -1);
+	if (!ri) {
+		return nullptr;
+	}
+	const int index = ri->index;
+	r_unref (ri);
+	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_REG, index);
+}
+
+static RAnalVar *MatchVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h) {
+	if (!hv.regNames.empty ()) {
+		for (const std::string &regName : hv.regNames) {
+			RAnalVar *var = MatchRegVar (core, fcn, regName);
+			if (var) {
+				return var;
+			}
+		}
+		return nullptr;
+	}
+	if (!hv.onStack) {
+		return nullptr;
+	}
+	// invert the stack mapping from FunctionVars::addr: negative deltas wrap to the top of the stack space
+	st64 gdelta = (hv.stackOff > h.stackHighest / 2)
+		? (st64)hv.stackOff - (st64)h.stackHighest - 1
+		: (st64)hv.stackOff;
+	int delta = (int)(gdelta - fcn->bp_off + h.extraPop);
+	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_BPV, delta);
+}
+
+static void WriteVar(RCore *core, RAnalFunction *fcn, const HarvestVar &hv, const Harvest &h, std::set<RAnalVar *> &seen, int *types, int *names) {
+	RAnalVar *var = MatchVar (core, fcn, hv, h);
+	if (!var) {
+		R_LOG_DEBUG ("pdgw: no r2 variable matches %s", hv.name.c_str ());
+		return;
+	}
+	// params and locals can share storage; the first (param) view wins
+	if (!seen.insert (var).second) {
+		return;
+	}
+	if (!hv.type.empty () && (!var->type || hv.type != var->type)) {
+		if (TypeParseable (core->anal, hv.type)) {
+			r_anal_var_set_type (core->anal, var, hv.type.c_str ());
+			(*types)++;
+		} else {
+			R_LOG_DEBUG ("pdgw: skipping unknown type %s", hv.type.c_str ());
+		}
+	}
+	if (hv.nameDefined && var->name && hv.name != var->name) {
+		if (r_anal_var_rename (core->anal, var, hv.name.c_str ())) {
+			(*names)++;
+		}
+	}
+}
+
+static void param_free(void *p) {
+	RAnalFunctionParam *fp = (RAnalFunctionParam *)p;
+	if (fp) {
+		free (fp->name);
+		free (fp->type);
+		free (fp);
+	}
+}
+
+static bool WriteSignature(RCore *core, RAnalFunction *fcn, const Harvest &h) {
+	RAnalFunctionSignature *cur = r_anal_function_get_signature (fcn);
+	const char *curRet = (cur && R_STR_ISNOTEMPTY (cur->ret_type)) ? cur->ret_type : NULL;
+	std::string ret = h.proto.retType;
+	if (ret.empty () || !TypeParseable (core->anal, ret)) {
+		ret = curRet ? curRet : "void";
+	} else if (ret == "void" && curRet && strcmp (curRet, "void")) {
+		// the decompiler demotes unused return values to void; never lose a known return type
+		ret = curRet;
+	}
+	RAnalFunctionSignature sig = {};
+	sig.ret_type = (char *)ret.c_str ();
+	sig.callconv = (char *)fcn->callconv;
+	sig.noreturn = h.proto.noreturn || fcn->is_noreturn;
+	sig.params = r_list_newf (param_free);
+	bool complete = true;
+	int idx = 0;
+	for (const HarvestVar &hv : h.proto.params) {
+		if (hv.type.empty () || !TypeParseable (core->anal, hv.type)) {
+			complete = false;
+			break;
+		}
+		RAnalFunctionParam *fp = R_NEW0 (RAnalFunctionParam);
+		std::string pname = hv.name;
+		if (!hv.nameDefined) {
+			RAnalVar *var = MatchVar (core, fcn, hv, h);
+			pname = (var && var->name) ? var->name : "arg" + std::to_string (idx + 1);
+		}
+		fp->name = strdup (pname.c_str ());
+		fp->type = strdup (hv.type.c_str ());
+		r_list_append (sig.params, fp);
+		idx++;
+	}
+	if (complete && h.proto.dotdotdot) {
+		RAnalFunctionParam *fp = R_NEW0 (RAnalFunctionParam);
+		fp->type = strdup ("...");
+		r_list_append (sig.params, fp);
+	}
+	bool changed = !cur;
+	if (complete && cur) {
+		changed = !cur->ret_type || ret != cur->ret_type
+			|| r_list_length (cur->params) != r_list_length (sig.params);
+		for (int i = 0; !changed && i < r_list_length (sig.params); i++) {
+			RAnalFunctionParam *pa = (RAnalFunctionParam *)r_list_get_n (cur->params, i);
+			RAnalFunctionParam *pb = (RAnalFunctionParam *)r_list_get_n (sig.params, i);
+			if (strcmp (r_str_get (pa->type), r_str_get (pb->type)) || strcmp (r_str_get (pa->name), r_str_get (pb->name))) {
+				changed = true;
+			}
+		}
+	}
+	bool applied = false;
+	if (complete && changed) {
+		applied = r_anal_function_set_signature (core->anal, fcn, &sig);
+		if (!applied) {
+			R_LOG_DEBUG ("pdgw: signature rejected by the type parser");
+		}
+	} else if (!complete) {
+		R_LOG_DEBUG ("pdgw: incomplete parameter types, not writing the signature");
+	}
+	r_list_free (sig.params);
+	r_anal_function_signature_free (cur);
+	return applied;
+}
+
+void WriteHarvest(RCore *core, RAnalFunction *fcn, const Harvest &h, bool writeVars, bool writeSig) {
+	int types = 0, names = 0;
+	bool sig = false;
+	if (writeVars) {
+		std::set<RAnalVar *> seen;
+		for (const HarvestVar &hv : h.proto.params) {
+			WriteVar (core, fcn, hv, h, seen, &types, &names);
+		}
+		for (const HarvestVar &hv : h.locals) {
+			WriteVar (core, fcn, hv, h, seen, &types, &names);
+		}
+	}
+	if (writeSig && h.proto.valid) {
+		sig = WriteSignature (core, fcn, h);
+	}
+	if (types || names || sig) {
+		R_LOG_INFO ("pdgw: wrote %d types, %d names%s", types, names, sig ? ", signature" : "");
+	} else {
+		R_LOG_INFO ("pdgw: no changes");
+	}
+}

--- a/src/r2harvest.h
+++ b/src/r2harvest.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 pancake
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef R2GHIDRA_R2HARVEST_H
+#define R2GHIDRA_R2HARVEST_H
+
+#include "R2Architecture.h"
+
+#include <r_core.h>
+#include <string>
+#include <vector>
+
+struct HarvestVar {
+	std::string name;
+	std::string type; // "" = don't retype
+	std::vector<std::string> regNames; // candidate registers, best match first; non-empty = register storage
+	uintb stackOff = 0;
+	bool onStack = false;
+	bool nameDefined = false;
+};
+
+struct HarvestProto {
+	bool valid = false;
+	std::string retType; // "" = keep the current return type
+	bool dotdotdot = false;
+	bool noreturn = false;
+	std::vector<HarvestVar> params;
+};
+
+struct Harvest {
+	HarvestProto proto;
+	std::vector<HarvestVar> locals;
+	int4 extraPop = 0;
+	uintb stackHighest = 0;
+};
+
+// copy the recovered prototype and locals into plain data so nothing references the arch after teardown
+void HarvestFuncdata(R2Architecture &arch, ghidra::Funcdata *func, Harvest &out);
+void WriteHarvest(RCore *core, RAnalFunction *fcn, const Harvest &h, bool writeVars, bool writeSig);
+
+#endif

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1870,3 +1870,42 @@ var int32_t var_8h @ ebp-0x8
 var int32_t var_ch @ ebp-0xc
 EOF
 RUN
+
+NAME=pdgw does not import auto-generated ghidra variable names
+FILE=bins/dectest64
+CMDS=<<EOF
+s main
+af
+e r2ghidra.vars=false
+pdgw
+afv
+EOF
+EXPECT=<<EOF
+pdgw: no changes
+arg int argc @ rdi
+arg char ** argv @ rsi
+var int64_t var_8h @ rbp-0x8
+var int64_t var_20h @ rbp-0x20
+var int64_t var_24h @ rbp-0x24
+var int64_t var_30h @ rbp-0x30
+EOF
+RUN
+
+NAME=pdgw converges when a ghidra local shares storage with a parameter
+FILE=bins/elf/arm64-varargs.so
+CMDS=<<EOF
+aaa
+s sym.p_snprintf
+e r2ghidra.varargs=true
+pdgw
+?e ----
+pdgw
+afv~arg1
+EOF
+EXPECT=<<EOF
+pdgw: applied 0 types, 0 names, signature
+----
+pdgw: no changes
+arg int64_t arg1 @ x0
+EOF
+RUN

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1716,3 +1716,157 @@ EXPECT=<<EOF
 void sym.Aeropause(char *arg1,int64_t arg2,int64_t arg3)
 EOF
 RUN
+
+NAME=pdgw applies the recovered register-arg type and signature
+FILE=bins/dectest64
+CMDS=<<EOF
+s sym.Aeropause
+af
+e r2ghidra.vars=false
+pdgw
+afv
+afs
+EOF
+EXPECT=<<EOF
+pdgw: applied 1 types, 0 names
+arg int64_t * arg1 @ rdi
+arg int64_t arg2 @ rsi
+arg int64_t arg3 @ rdx
+var int64_t var_8h @ rbp-0x8
+var int64_t var_ch @ rbp-0xc
+var int64_t var_18h @ rbp-0x18
+void sym.Aeropause (int64_t arg1, int64_t arg2, int64_t arg3);
+EOF
+RUN
+
+NAME=pdgw applied twice makes no further changes
+FILE=bins/dectest64
+CMDS=<<EOF
+s sym.Aeropause
+af
+e r2ghidra.vars=false
+pdgw
+?e ----
+pdgw
+afv
+EOF
+EXPECT=<<EOF
+pdgw: applied 1 types, 0 names
+----
+pdgw: no changes
+arg int64_t * arg1 @ rdi
+arg int64_t arg2 @ rsi
+arg int64_t arg3 @ rdx
+var int64_t var_8h @ rbp-0x8
+var int64_t var_ch @ rbp-0xc
+var int64_t var_18h @ rbp-0x18
+EOF
+RUN
+
+NAME=pdg output improves after pdgw applies types
+FILE=bins/dectest64
+CMDS=<<EOF
+s sym.Aeropause
+af
+pdg~Aeropause(
+e r2ghidra.vars=false
+pdgw
+e r2ghidra.vars=true
+pdg~Aeropause(
+EOF
+EXPECT=<<EOF
+void sym.Aeropause(int64_t arg1,int64_t arg2,int64_t arg3)
+pdgw: applied 1 types, 0 names
+void sym.Aeropause(int64_t *arg1,int64_t arg2,int64_t arg3)
+EOF
+RUN
+
+NAME=pdgw with apply gates disabled writes nothing
+FILE=bins/dectest64
+CMDS=<<EOF
+s sym.Aeropause
+af
+e r2ghidra.vars=false
+e r2ghidra.apply.vars=false
+e r2ghidra.apply.sig=false
+pdgw
+afv~arg1
+EOF
+EXPECT=<<EOF
+pdgw: no changes
+arg int64_t arg1 @ rdi
+EOF
+RUN
+
+NAME=pdgw applies the recovered signature on big endian ppc64
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+aaa
+s sym..crc32_init
+pdgw
+afs
+?e ----
+pdgw
+EOF
+EXPECT=<<EOF
+pdgw: applied 0 types, 0 names, signature
+void sym..crc32_init (int64_t arg1);
+----
+pdgw: no changes
+EOF
+RUN
+
+NAME=pdgw preserves an existing explicit prototype
+FILE=bins/elf/hello_world
+CMDS=<<EOF
+aaa
+s main
+"afs int main(int argc, char **argv)"
+pdgw
+afs
+EOF
+EXPECT=<<EOF
+pdgw: no changes
+int main (int argc, char **argv);
+EOF
+RUN
+
+NAME=pdgw applies the recovered signature on arm64
+FILE=bins/elf/arm64-varargs.so
+CMDS=<<EOF
+aaa
+s sym.p_snprintf
+pdgw
+afs
+?e ----
+pdgw
+EOF
+EXPECT=<<EOF
+pdgw: applied 0 types, 0 names, signature
+void sym.p_snprintf (int64_t arg1, int64_t arg2);
+----
+pdgw: no changes
+EOF
+RUN
+
+NAME=pdgw is stable on 32-bit x86 stack arguments
+FILE=bins/elf/crackme0x05
+CMDS=<<EOF
+s sym.check
+af
+e r2ghidra.vars=false
+pdgw
+?e ----
+pdgw
+afv
+EOF
+EXPECT=<<EOF
+pdgw: no changes
+----
+pdgw: no changes
+arg int32_t arg_8h @ ebp+0x8
+var int32_t var_8h @ ebp-0x8
+var int32_t var_ch @ ebp-0xc
+EOF
+RUN

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1717,18 +1717,19 @@ void sym.Aeropause(char *arg1,int64_t arg2,int64_t arg3)
 EOF
 RUN
 
-NAME=pdgw applies the recovered register-arg type and signature
+NAME=pdgw writes the recovered register-arg type and signature
 FILE=bins/dectest64
+ARGS=-e log.level=0
 CMDS=<<EOF
 s sym.Aeropause
 af
 e r2ghidra.vars=false
+e log.level=2
 pdgw
 afv
 afs
 EOF
 EXPECT=<<EOF
-pdgw: applied 1 types, 0 names
 arg int64_t * arg1 @ rdi
 arg int64_t arg2 @ rsi
 arg int64_t arg3 @ rdx
@@ -1737,23 +1738,24 @@ var int64_t var_ch @ rbp-0xc
 var int64_t var_18h @ rbp-0x18
 void sym.Aeropause (int64_t arg1, int64_t arg2, int64_t arg3);
 EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: wrote 1 types, 0 names
+EOF
 RUN
 
-NAME=pdgw applied twice makes no further changes
+NAME=pdgw run twice makes no further changes
 FILE=bins/dectest64
+ARGS=-e log.level=0
 CMDS=<<EOF
 s sym.Aeropause
 af
 e r2ghidra.vars=false
+e log.level=2
 pdgw
-?e ----
 pdgw
 afv
 EOF
 EXPECT=<<EOF
-pdgw: applied 1 types, 0 names
-----
-pdgw: no changes
 arg int64_t * arg1 @ rdi
 arg int64_t arg2 @ rsi
 arg int64_t arg3 @ rdx
@@ -1761,9 +1763,13 @@ var int64_t var_8h @ rbp-0x8
 var int64_t var_ch @ rbp-0xc
 var int64_t var_18h @ rbp-0x18
 EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: wrote 1 types, 0 names
+INFO: pdgw: no changes
+EOF
 RUN
 
-NAME=pdg output improves after pdgw applies types
+NAME=pdg output improves after pdgw writes types
 FILE=bins/dectest64
 CMDS=<<EOF
 s sym.Aeropause
@@ -1776,112 +1782,125 @@ pdg~Aeropause(
 EOF
 EXPECT=<<EOF
 void sym.Aeropause(int64_t arg1,int64_t arg2,int64_t arg3)
-pdgw: applied 1 types, 0 names
 void sym.Aeropause(int64_t *arg1,int64_t arg2,int64_t arg3)
 EOF
 RUN
 
-NAME=pdgw with apply gates disabled writes nothing
+NAME=pdgw with write gates disabled changes nothing
 FILE=bins/dectest64
+ARGS=-e log.level=0
 CMDS=<<EOF
 s sym.Aeropause
 af
 e r2ghidra.vars=false
-e r2ghidra.apply.vars=false
-e r2ghidra.apply.sig=false
+e r2ghidra.write.vars=false
+e r2ghidra.write.sig=false
+e log.level=2
 pdgw
 afv~arg1
 EOF
 EXPECT=<<EOF
-pdgw: no changes
 arg int64_t arg1 @ rdi
+EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: no changes
 EOF
 RUN
 
-NAME=pdgw applies the recovered signature on big endian ppc64
+NAME=pdgw writes the recovered signature on big endian ppc64
 FILE=bins/elf/ppc64v1-crc32_generic.ko
-ARGS=-e bin.relocs.apply=true
+ARGS=-e bin.relocs.apply=true -e log.level=0
 CMDS=<<EOF
 aaa
 s sym..crc32_init
+e log.level=2
 pdgw
 afs
-?e ----
 pdgw
 EOF
 EXPECT=<<EOF
-pdgw: applied 0 types, 0 names, signature
 void sym..crc32_init (int64_t arg1);
-----
-pdgw: no changes
+EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: wrote 0 types, 0 names, signature
+INFO: pdgw: no changes
 EOF
 RUN
 
 NAME=pdgw preserves an existing explicit prototype
 FILE=bins/elf/hello_world
+ARGS=-e log.level=0
 CMDS=<<EOF
 aaa
 s main
 "afs int main(int argc, char **argv)"
+e log.level=2
 pdgw
 afs
 EOF
 EXPECT=<<EOF
-pdgw: no changes
 int main (int argc, char **argv);
+EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: no changes
 EOF
 RUN
 
-NAME=pdgw applies the recovered signature on arm64
+NAME=pdgw writes the recovered signature on arm64
 FILE=bins/elf/arm64-varargs.so
+ARGS=-e log.level=0
 CMDS=<<EOF
 aaa
 s sym.p_snprintf
+e log.level=2
 pdgw
 afs
-?e ----
 pdgw
 EOF
 EXPECT=<<EOF
-pdgw: applied 0 types, 0 names, signature
 void sym.p_snprintf (int64_t arg1, int64_t arg2);
-----
-pdgw: no changes
+EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: wrote 0 types, 0 names, signature
+INFO: pdgw: no changes
 EOF
 RUN
 
 NAME=pdgw is stable on 32-bit x86 stack arguments
 FILE=bins/elf/crackme0x05
+ARGS=-e log.level=0
 CMDS=<<EOF
 s sym.check
 af
 e r2ghidra.vars=false
+e log.level=2
 pdgw
-?e ----
 pdgw
 afv
 EOF
 EXPECT=<<EOF
-pdgw: no changes
-----
-pdgw: no changes
 arg int32_t arg_8h @ ebp+0x8
 var int32_t var_8h @ ebp-0x8
 var int32_t var_ch @ ebp-0xc
+EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: no changes
+INFO: pdgw: no changes
 EOF
 RUN
 
 NAME=pdgw does not import auto-generated ghidra variable names
 FILE=bins/dectest64
+ARGS=-e log.level=0
 CMDS=<<EOF
 s main
 af
 e r2ghidra.vars=false
+e log.level=2
 pdgw
 afv
 EOF
 EXPECT=<<EOF
-pdgw: no changes
 arg int argc @ rdi
 arg char ** argv @ rsi
 var int64_t var_8h @ rbp-0x8
@@ -1889,23 +1908,28 @@ var int64_t var_20h @ rbp-0x20
 var int64_t var_24h @ rbp-0x24
 var int64_t var_30h @ rbp-0x30
 EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: no changes
+EOF
 RUN
 
 NAME=pdgw converges when a ghidra local shares storage with a parameter
 FILE=bins/elf/arm64-varargs.so
+ARGS=-e log.level=0
 CMDS=<<EOF
 aaa
 s sym.p_snprintf
 e r2ghidra.varargs=true
+e log.level=2
 pdgw
-?e ----
 pdgw
 afv~arg1
 EOF
 EXPECT=<<EOF
-pdgw: applied 0 types, 0 names, signature
-----
-pdgw: no changes
 arg int64_t arg1 @ x0
+EOF
+EXPECT_ERR=<<EOF
+INFO: pdgw: wrote 0 types, 0 names, signature
+INFO: pdgw: no changes
 EOF
 RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

`pdgw` decompiles the current function and writes the results back into r2 instead of printing: variable types and names (matched by register or stack storage) and the function signature (return type, params, varargs, noreturn).

- Gated by `r2ghidra.write.vars` and `r2ghidra.write.sig` (both default true)
- Conservative: skips ghidra auto-generated names, types r2 can't parse, and never demotes a known return type to void
- Idempotent: a second run reports no changes; runs in-process so the writes land in the session
- Harvest/write-back logic lives in the new `src/r2harvest.cpp`; results are reported via `R_LOG_INFO`
- Tests cover x86-64, x86-32 stack args, arm64 and big-endian ppc64
