### PR TITLE
Parse the ,... variadic marker in sdb signatures instead of emitting a phantom call-site arg

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -405,12 +405,13 @@ static void processFunctionSignature(
 				}
 				std::string arg_type_str = arg_type;
 				free (arg_type);
-				if (arg_type_str == "...") {
+				const char *arg_name = r_type_func_args_name (tdb, fname, i);
+				// the variadic slot is stored as `,...` so the marker lands in the name, not the type
+				if (arg_type_str == "..." || (arg_name && !strcmp (arg_name, "..."))) {
 					sig_first_vararg = i;
 					break;
 				}
 
-				const char *arg_name = r_type_func_args_name (tdb, fname, i);
 				std::string name = (R_STR_ISNOTEMPTY (arg_name))
 					? std::string (arg_name)
 					: ("arg" + to_string (i));

--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -646,7 +646,9 @@ Datatype *R2TypeFactory::queryR2Function(const string &n, std::set<std::string> 
 
 	for (int i = 0; i < arg_count; i++) {
 		char *arg_type = r_type_func_args_type(sdb, n.c_str(), i);
-		if (arg_type && !strcmp(arg_type, "...")) {
+		const char *arg_name = r_type_func_args_name(sdb, n.c_str(), i);
+		// the variadic slot is stored as `,...` so the marker lands in the name, not the type
+		if ((arg_type && !strcmp(arg_type, "...")) || (arg_name && !strcmp(arg_name, "..."))) {
 			proto.firstVarArgSlot = proto.intypes.size();
 			free(arg_type);
 			continue;
@@ -660,8 +662,6 @@ Datatype *R2TypeFactory::queryR2Function(const string &n, std::set<std::string> 
 			arg = getBase(1, TYPE_UNKNOWN);
 		}
 		proto.intypes.push_back(arg);
-
-		const char *arg_name = r_type_func_args_name(sdb, n.c_str(), i);
 		proto.innames.push_back(arg_name ? arg_name : "");
 
 		if (arg_type) {

--- a/test/db/extras/r2ghidra_output
+++ b/test/db/extras/r2ghidra_output
@@ -1130,7 +1130,7 @@ EXPECT=<<EOF2
 EOF2
 RUN
 
-NAME=printf vararg recovery stays off by default
+NAME=vararg recovery off leaves call-site args to decompiler liveness
 FILE=bins/elf/x86_64-varargs.so
 ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF2
@@ -1139,7 +1139,7 @@ aaa
 pdg @ sym.p_printf~%f
 EOF2
 EXPECT=<<EOF2
-    sym.imp.printf("%s %d %f %x\n",arg1);
+    iVar1 = sym.imp.printf("%s %d %f %x\n",in_d0,arg1,arg2 & 0xffffffff,arg3 & 0xffffffff);
 EOF2
 RUN
 
@@ -1216,7 +1216,7 @@ aaa
 pdg @ main~IOLI
 EOF2
 EXPECT=<<EOF2
-    sym.imp.printf("IOLI Crackme Level 0x05\n",in_stack_ffffff64);
+    sym.imp.printf("IOLI Crackme Level 0x05\n");
 EOF2
 RUN
 

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1858,7 +1858,7 @@ afs
 pdgw
 EOF
 EXPECT=<<EOF
-void sym.p_snprintf (int64_t arg1, int64_t arg2);
+int sym.p_snprintf (int64_t arg1, int64_t arg2);
 EOF
 EXPECT_ERR=<<EOF
 INFO: pdgw: wrote 0 types, 0 names, signature


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

radare2 9d6619ee4f stores the variadic slot of libc signatures as `func.<name>.arg.N=,...` — empty type, with `...` as the arg *name*. R2Scope.cpp and R2TypeFactory.cpp only checked the type side, so the marker was parsed as a real locked parameter: `printf` reached the decompiler as a non-variadic 2-arg function and every call site grew a phantom argument (`in_stack_ffffff64` on x86-32):

    sym.imp.printf("IOLI Crackme Level 0x05\n",in_stack_ffffff64);

Fix: detect the marker by name as well (as parse_variadic_sig already does), so the prototype ends its fixed args there and carries a proper vararg slot.

Refreshes three test expectations that had pinned the buggy output while it was live: the two x86-64/x86-32 vararg gate pins, and the arm64 pdgw signature (`void` → `int`: with snprintf's return type no longer starved, the recovered value visibly flows to w0 at ret).

