### PR TITLE
Expect the default cspec in the e500mc sleigh id since ghidra ships no ppc gcc cspec

### DIFF
--- a/test/db/extras/r2ghidra_arch
+++ b/test/db/extras/r2ghidra_arch
@@ -421,7 +421,7 @@ CMDS=<<EOF
 pdgss
 EOF
 EXPECT=<<EOF
-PowerPC:BE:32:e500mc:gcc
+PowerPC:BE:32:e500mc:default
 EOF
 RUN
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

ghidra's PowerPC module defines no gcc cspec, so the old pin was an invalid id emitted before the compiler-string normalization from #268; the normalized default is the only cspec that exists for PowerPC:BE:32:e500mc.