### PR TITLE
Resolve compiler cspecs by id from the language definitions instead of a hardcoded name list

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -11,7 +11,7 @@
 
 using namespace ghidra;
 
-std::string CompilerFromCore(RCore *core);
+std::string CompilerFromCore(RCore *core, const std::string &lang_base);
 
 template<typename T> class BaseMapper {
 	private:
@@ -49,8 +49,8 @@ class ArchMapper {
 	private:
 		const Mapper<std::string> arch;
 		const Mapper<std::string> flavor;
-		const Mapper<bool> big_endian;
 		const Mapper<ut64> bits;
+		const Mapper<bool> big_endian;
 
 	public:
 		const int minopsz;
@@ -70,12 +70,12 @@ class ArchMapper {
 			, minopsz(minopsz)
 			, maxopsz(maxopsz) {}
 
+		// language id without the compiler field; the caller appends the resolved cspec id
 		std::string Map(RCore *core) const {
 			return arch.Map(core)
 				+ ":" + (big_endian.Map(core) ? "BE" : "LE")
 				+ ":" + to_string(bits.Map(core))
-				+ ":" + flavor.Map(core)
-				+ ":" + CompilerFromCore(core);
+				+ ":" + flavor.Map(core);
 		}
 };
 
@@ -280,169 +280,121 @@ static const std::map<std::string, ArchMapper> arch_map = {
 	{ "sbpf", { S("sBPF"), S("default"), B(64), E(false) } }
 };
 
-const char *ghidraCompilers[] = {
-	"6502.default",
-	"68000.default",
-	"6805.default",
-	"8048.default",
-	"8051.Archimedes",
-	"8051.default",
-	"8085.default",
-	"AARCH64.Visual Studio",
-	"AARCH64.default",
-	"ARM.Visual Studio",
-	"ARM.default",
-	"AppleSilicon.default",
-	"CP1600.default",
-	"CR16.default",
-	"Dalvik.default",
-	"HC05.default",
-	"HC08.default",
-	"HCS08.default",
-	"HCS12.default",
-	"JVM.default",
-	"MCS96.default",
-	"PIC24.default",
-	"STM8.default",
-	"SparcV9.default",
-	"SuperH4.Visual Studio",
-	"SuperH4.default",
-	"TI_MSP430.default",
-	"V850.default",
-	"avr32a.default",
-	"avr8.gcc",
-	"avr8.iarV1",
-	"avr8.imgCraftV8",
-	"hexagon.default",
-	"m8c.default",
-	"mips.Visual Studio",
-	"mips.default",
-	"mips.n32",
-	"mips.o32",
-	"mips.o64",
-	"old/v01stuff/toy.default",
-	"pa-risc.default",
-	"pic12c5xx.default",
-	"pic16.default",
-	"pic16c5x.default",
-	"pic17c7xx.default",
-	"pic18.default",
-	"ppc.Mac OS X",
-	"ppc.Visual Studio",
-	"ppc.default",
-	"riscv.gcc",
-	"superh.default",
-	"toy.default",
-	"toy.posStack",
-	"tricore.default",
-	"x86.Borland C++",
-	"x86.Delphi",
-	"x86.Visual Studio",
-	"x86.clang",
-	"x86.default",
-	"x86.gcc",
-	"z80.default",
-	NULL
-};
-
-// short names for the cspecs that are awkward to type via `e r2ghidra.compiler=`
 static const std::map<std::string, std::string> compiler_alias = {
-	{ "vs", "Visual Studio" },
-	{ "msvc", "Visual Studio" },
-	{ "windows", "Visual Studio" },
-	{ "mach0", "Mac OS X" },
-	{ "macos", "Mac OS X" },
-	{ "osx", "Mac OS X" },
+	{ "vs", "windows" },
+	{ "msvc", "windows" },
+	{ "visual studio", "windows" },
+	{ "mach0", "macosx" },
+	{ "macos", "macosx" },
+	{ "osx", "macosx" },
 };
 
 static const std::map<std::string, std::string> compiler_map = {
 	{ "elf", "gcc" },
-	{ "pe", "Visual Studio" },
-	{ "mach0", "clang" },
+	{ "pe", "windows" },
+	{ "mach0", "gcc" }, // apple ABIs are SysV-based; the x86 "clang" cspec is a windows profile
 };
 
-std::string findGhidraCompiler(RCore *core, const char *bin_compiler) {
+static const LanguageDescription *matchLanguage(const std::string &lang_id) {
+	R2Architecture::collectSpecFiles (std::cerr);
+	for (const auto &lang : R2Architecture::getLanguageDescriptions ()) {
+		if (lang.getId () == lang_id) {
+			return &lang;
+		}
+	}
+	return nullptr;
+}
+
+// resolve a hint (cspec id, name, alias or bin compiler string like "GCC: 9.2.0") to a cspec id the language really ships
+static std::string findCompilerForLanguage(RCore *core, const char *hint, const std::string &lang_id) {
+	const LanguageDescription *lang = matchLanguage (lang_id);
+	if (!strcmp (hint, "?")) {
+		if (lang != nullptr) {
+			for (int4 i = 0; i < lang->numCompilers (); i++) {
+				const CompilerTag &tag = lang->getCompiler (i);
+				r_cons_printf (core->cons, "%s  (%s)\n", tag.getId ().c_str (), tag.getName ().c_str ());
+			}
+		}
+		return std::string ("default");
+	}
+	std::string h = tolower (hint);
+	auto ali = compiler_alias.find (h);
+	if (ali != compiler_alias.end ()) {
+		h = ali->second;
+	}
+	if (lang == nullptr) {
+		return std::string ("default");
+	}
+	// x86 names its windows-clang cspec plainly "clang"; only a windows-ish hint may pick it
+	auto usable = [&h](const CompilerTag &tag) {
+		return tag.getId () != "clangwindows" || h.find ("windows") != std::string::npos;
+	};
+	for (int4 i = 0; i < lang->numCompilers (); i++) {
+		const CompilerTag &tag = lang->getCompiler (i);
+		if (usable (tag) && (tolower (tag.getId ()) == h || tolower (tag.getName ()) == h)) {
+			return tag.getId ();
+		}
+	}
+	for (int4 i = 0; i < lang->numCompilers (); i++) {
+		const CompilerTag &tag = lang->getCompiler (i);
+		if (usable (tag) && (h.find (tolower (tag.getName ())) != std::string::npos || h.find (tolower (tag.getId ())) != std::string::npos)) {
+			return tag.getId ();
+		}
+	}
+	// no match: prefer default then gcc; never the first tag blindly (x86 lists windows first)
+	for (const char *fb : { "default", "gcc" }) {
+		for (int4 i = 0; i < lang->numCompilers (); i++) {
+			if (lang->getCompiler (i).getId () == fb) {
+				return std::string (fb);
+			}
+		}
+	}
+	return lang->numCompilers () > 0? lang->getCompiler (0).getId (): std::string ("default");
+}
+
+static std::string sleighIdBaseFromCore(RCore *core) {
 	const char *arch = r_config_get (core->config, "asm.arch");
 	if (R_STR_ISEMPTY (arch)) {
-		return std::string("default");
+		return std::string ();
 	}
 	if (!strcmp (arch, "r2ghidra")) {
 		arch = r_config_get (core->config, "asm.cpu");
 	}
-	
-	char *a = strdup (arch);
-	// take arch name by splitting by the dot.
-	char *dot = strchr (a, '.');
-	if (dot) {
-		*dot = 0;
+	std::string a = arch? arch: "";
+	const size_t dot = a.find ('.');
+	if (dot != std::string::npos) {
+		a.resize (dot);
 	}
-	// asm.arch "arm" is "ARM" (32-bit) or "AARCH64" (64-bit) in Ghidra's processor naming
-	if (!strcmp (a, "arm")) {
-		free (a);
-		a = strdup (r_config_get_i (core->config, "asm.bits") == 64? "AARCH64": "ARM");
-	}
-	char *b = r_str_newf ("%s.", a);
-	free (a);
-	const char *uc = bin_compiler;
-	if (!strcmp (uc, "?")) {
-		for (int i = 0; ghidraCompilers[i]; i++) {
-			if (r_str_startswith (ghidraCompilers[i], b)) {
-				const char *c = ghidraCompilers[i] + strlen (b);
-				r_cons_printf (core->cons, "%s\n", c);
-			}
-		}
-		free (b);
-		return std::string("default");
-	}
-	if (R_STR_ISEMPTY (bin_compiler) || !strcmp (uc, "default")) {
-		bin_compiler = uc;
-	}
-	auto ali = compiler_alias.find (tolower (bin_compiler));
-	if (ali != compiler_alias.end ()) {
-		bin_compiler = ali->second.c_str ();
-	}
-	const char *goodcompiler = NULL;
-	for (int i = 0; ghidraCompilers[i]; i++) {
-		if (r_str_startswith (ghidraCompilers[i], b)) {
-			const char *c = ghidraCompilers[i] + strlen (b);
-			goodcompiler = c;
-			if (R_STR_ISEMPTY (bin_compiler) || !r_str_casecmp (c, bin_compiler)) {
-				break;
-			}
-		}
-	}
-	free (b);
-	if (goodcompiler != NULL) {
-		return std::string(goodcompiler);
-	}
-	if (r_str_startswith (arch, "x86")) {
-		return std::string("gcc");
-	}
-	return std::string("default");
+	auto arch_it = arch_map.find (a);
+	return arch_it == arch_map.end ()? std::string (): arch_it->second.Map (core);
 }
 
-std::string CompilerFromCore(RCore *core) {
+std::string findGhidraCompiler(RCore *core, const char *bin_compiler) {
+	return findCompilerForLanguage (core, bin_compiler, sleighIdBaseFromCore (core));
+}
+
+std::string CompilerFromCore(RCore *core, const std::string &lang_base) {
 	if (core == nullptr) {
 		return "gcc";
 	}
 	// an explicit r2ghidra.compiler selects the cspec; "default" defers to the binary
 	const char *want = r_config_get (core->config, "r2ghidra.compiler");
 	if (R_STR_ISNOTEMPTY (want) && strcmp (want, "default")) {
-		return findGhidraCompiler (core, want);
+		return findCompilerForLanguage (core, want, lang_base);
 	}
 	RBinInfo *info = r_bin_get_info (core->bin);
 	if (!info || !info->rclass) {
 		return std::string ();
 	}
 	if (R_STR_ISNOTEMPTY (info->compiler)) {
-		// the bin's compiler string ("GCC: (GNU) 9.2.0") is not a cspec name; normalize it
-		return findGhidraCompiler (core, info->compiler);
+		return findCompilerForLanguage (core, info->compiler, lang_base);
 	}
 	auto comp_it = compiler_map.find (info->rclass);
 	if (comp_it == compiler_map.end ()) {
 		return std::string ();
 	}
-	return comp_it->second;
+	// the container guess must still be a cspec the language really has
+	return findCompilerForLanguage (core, comp_it->second.c_str (), lang_base);
 }
 
 std::string SleighIdFromCore(RCore *core) {
@@ -464,7 +416,8 @@ std::string SleighIdFromCore(RCore *core) {
 	if (arch_it == arch_map.end ()) {
 		throw LowlevelError ("Could not match asm.arch " + std::string(arch) + " to sleigh arch.");
 	}
-	return arch_it->second.Map (core);
+	std::string base = arch_it->second.Map (core);
+	return base + ":" + CompilerFromCore (core, base);
 }
 
 int ai(RCore *core, std::string cpu, int query) {
@@ -494,7 +447,8 @@ std::string SleighIdFromSleighAsmConfig(RCore *core, const char *cpu, int bits, 
 	}
 	auto arch_it = arch_map.find(cpu);
 	if (arch_it != arch_map.end()) {
-		return arch_it->second.Map (core);
+		std::string base = arch_it->second.Map (core);
+		return base + ":" + CompilerFromCore (core, base);
 	}
 	// short form if possible
 	std::string low_cpu = tolower (cpu);

--- a/test/db/extras/ghidra_arch
+++ b/test/db/extras/ghidra_arch
@@ -249,12 +249,12 @@ EXPECT=<<EOF
 
 //WARNING: Variable defined which should be unmapped: var_4h
 
-void __stdcall main(int argc,char **argv,char **envp)
+void main(int argc,char **argv,char **envp)
 
 {
     int64_t var_4h;
     
-    sym._call();
+    sym._call("hello",0x100000faa);
     return;
 }
 

--- a/test/db/extras/r2ghidra_arch
+++ b/test/db/extras/r2ghidra_arch
@@ -249,12 +249,12 @@ EXPECT=<<EOF
 
 //WARNING: Variable defined which should be unmapped: var_4h
 
-void __stdcall main(int argc,char **argv,char **envp)
+void main(int argc,char **argv,char **envp)
 
 {
     int64_t var_4h;
     
-    sym._call();
+    sym._call("hello",0x100000faa);
     return;
 }
 
@@ -431,7 +431,7 @@ CMDS=<<EOF
 pdgss
 EOF
 EXPECT=<<EOF
-PowerPC:BE:64:A2ALT:gcc
+PowerPC:BE:64:A2ALT:default
 EOF
 RUN
 

--- a/test/db/extras/r2ghidra_arch
+++ b/test/db/extras/r2ghidra_arch
@@ -421,7 +421,7 @@ CMDS=<<EOF
 pdgss
 EOF
 EXPECT=<<EOF
-PowerPC:BE:32:e500mc:gcc
+PowerPC:BE:32:e500mc:default
 EOF
 RUN
 

--- a/test/db/extras/r2ghidra_output
+++ b/test/db/extras/r2ghidra_output
@@ -1027,12 +1027,11 @@ CMDS=<<EOF2
 e r2ghidra.compiler=?
 EOF2
 EXPECT=<<EOF2
-Borland C++
-Delphi
-Visual Studio
-clang
-default
-gcc
+windows  (Visual Studio)
+clangwindows  (clang)
+gcc  (gcc)
+golang  (golang)
+swift  (Swift)
 EOF2
 RUN
 
@@ -1042,11 +1041,9 @@ CMDS=<<EOF2
 e r2ghidra.compiler=?
 EOF2
 EXPECT=<<EOF2
-Visual Studio
-default
-n32
-o32
-o64
+default  (default)
+windows  (Visual Studio)
+eabi  (eabi)
 EOF2
 RUN
 
@@ -1056,9 +1053,7 @@ CMDS=<<EOF2
 e r2ghidra.compiler=?
 EOF2
 EXPECT=<<EOF2
-Mac OS X
-Visual Studio
-default
+default  (default)
 EOF2
 RUN
 
@@ -1073,25 +1068,25 @@ gcc
 EOF2
 RUN
 
-NAME=r2ghidra.compiler expands a short alias to the full cspec name
+NAME=r2ghidra.compiler resolves an alias to the cspec id
 FILE=bins/dectest64
 CMDS=<<EOF2
-e r2ghidra.compiler=windows
+e r2ghidra.compiler=vs
 e r2ghidra.compiler
 EOF2
 EXPECT=<<EOF2
-Visual Studio
+windows
 EOF2
 RUN
 
-NAME=r2ghidra.compiler keeps a valid compiler name
+NAME=r2ghidra.compiler keeps a valid cspec id
 FILE=bins/dectest64
 CMDS=<<EOF2
-e r2ghidra.compiler=clang
+e r2ghidra.compiler=clangwindows
 e r2ghidra.compiler
 EOF2
 EXPECT=<<EOF2
-clang
+clangwindows
 EOF2
 RUN
 
@@ -1101,19 +1096,29 @@ CMDS=<<EOF2
 e r2ghidra.compiler=?
 EOF2
 EXPECT=<<EOF2
-Visual Studio
-default
+default  (default)
+windows  (Visual Studio)
+apcs  (APCS)
 EOF2
 RUN
 
+NAME=mach0 clang compiler string resolves the sysv gcc cspec
+FILE=bins/mach0/arg
+CMDS=<<EOF2
+pdgss
+EOF2
+EXPECT=<<EOF2
+x86:LE:64:default:gcc
+EOF2
+RUN
 NAME=r2ghidra.compiler selects the cspec in the matched language id
 FILE=bins/dectest64
 CMDS=<<EOF2
-e r2ghidra.compiler=clang
+e r2ghidra.compiler=clangwindows
 pd:gss
 EOF2
 EXPECT=<<EOF2
-x86:LE:64:default:clang
+x86:LE:64:default:clangwindows
 EOF2
 RUN
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Stacked on #276  (includes its one-line e500mc golden commit); will rebase once it merges.

Ghidra resolves the last field of a language id by cspec *id* (`windows`, `macosx`, `gcc`), falling back silently to `default` — or to the language's first cspec when it has no `default` id. r2ghidra picked compilers by cspec *name* from a hardcoded per-arch list, so:

- mach0 x86-64 decompiled with the *Windows* cspec (`clang` resolved to nothing and x86-64's first tag is `windows`): call args were dropped and prototypes grew `__stdcall` — see the macos-args golden, which now recovers `sym._call("hello",0x100000faa)`.
- PE's `:Visual Studio` suffix never matched id `windows`, landing on the default cspec.
- an unmatched compiler string returned the *last* list entry: on mips that's `o64`, a valid but wrong 64-bit ABI.
- `PowerPC:BE:64:A2ALT:gcc` and friends were invalid ids (ghidra ships no ppc gcc cspec).

Resolve hints per-language from getLanguageDescriptions() instead: exact id/name match, then substring (for bin strings like "GCC: (Ubuntu 15.2.0)"), then default/gcc fallback; always emit ids. The x86 cspec plainly named "clang" is a windows profile (`clangwindows`), so it's only picked by a windows-ish hint. Deletes the hardcoded list; `r2ghidra.compiler=?` now lists the matched language's real cspecs as `id  (name)`.