### PR TITLE
Build prototype models from r2 calling convention data

### DIFF
--- a/src/R2Architecture.cpp
+++ b/src/R2Architecture.cpp
@@ -198,6 +198,7 @@ ProtoModel *R2Architecture::buildProtoModelFromR2CC(const char *cc) {
 	}
 	childPentry (output, retvn, isFloatReg (anal, rloc));
 
+#if R2_VERSION_NUMBER >= 60109
 	std::vector<std::pair<const VarnodeData *, bool>> effects;
 	bool anyclobber = false;
 	static const int regtypes[] = {
@@ -247,6 +248,7 @@ ProtoModel *R2Architecture::buildProtoModelFromR2CC(const char *cc) {
 			});
 		}
 	}
+#endif
 
 	XmlDecode dec (this, &doc);
 	return decodeProto (dec);

--- a/src/R2Architecture.cpp
+++ b/src/R2Architecture.cpp
@@ -18,21 +18,54 @@ using namespace ghidra;
 
 #include "Dalvik.inc.cpp"
 
-// maps radare2 calling conventions to decompiler proto models
-static const std::map<std::string, std::string> cc_map = {
-	{ "cdecl", "__cdecl" },
-	{ "fastcall", "__fastcall" },
-	{ "ms", "__fastcall" },
-	{ "stdcall", "__stdcall" },
-	{ "cdecl-thiscall-ms", "__thiscall" },
-	{ "sh32", "__stdcall" },
-	{ "amd64", "__stdcall" },
-	{ "arm64", "__cdecl" },
-	{ "arm32", "__stdcall" },
-	{ "arm16", "__stdcall" }, /* not actually __stdcall */
-	{ "ppc-32", "__stdcall" }, /* PPC cspec default_proto: r3-r10 GPR / f1-f13 FP */
-	{ "ppc-64", "__stdcall" }
+// maps radare2 calling conventions to proto model names, tried in order against the loaded cspec
+static const std::map<std::string, std::vector<std::string>> cc_map = {
+	{ "cdecl", { "__cdecl" } },
+	{ "fastcall", { "__fastcall" } },
+	{ "ms", { "__fastcall", "MSABI" } }, // MSABI covers the x86-64 gcc cspec, which has no __fastcall
+	{ "stdcall", { "__stdcall" } },
+	{ "cdecl-thiscall-ms", { "__thiscall" } },
+	{ "sh32", { "__stdcall" } },
+	{ "amd64", { "__stdcall" } },
+	{ "arm64", { "__cdecl" } },
+	{ "arm32", { "__stdcall" } },
+	{ "arm16", { "__stdcall" } }, /* not actually __stdcall */
+	{ "ppc-32", { "__stdcall" } }, /* PPC cspec default_proto: r3-r10 GPR / f1-f13 FP */
+	{ "ppc-64", { "__stdcall" } }
 };
+
+static bool isFloatReg(RAnal *anal, const char *name) {
+	RRegItem *item = r_reg_get (anal->reg, name, -1);
+	if (!item) {
+		return false;
+	}
+	int type = item->type;
+	r_unref (item);
+	switch (type) {
+	case R_REG_TYPE_FPU:
+	case R_REG_TYPE_VEC64:
+	case R_REG_TYPE_VEC128:
+	case R_REG_TYPE_VEC256:
+	case R_REG_TYPE_VEC512:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static void childPentry(Element *parent, const VarnodeData *vn, bool flt) {
+	auto pentry = child (parent, "pentry", {
+		{ "minsize", "1" },
+		{ "maxsize", std::to_string (vn->size) }
+	});
+	if (flt) {
+		pentry->addAttribute ("storage", "float");
+	}
+	child (pentry, "addr", {
+		{ "space", vn->space->getName () },
+		{ "offset", hex (vn->offset) }
+	});
+}
 
 std::string FilenameFromCore(RCore *core) {
 	if (core && core->bin && core->bin->file) {
@@ -60,14 +93,163 @@ const std::vector<LanguageDescription> &R2Architecture::getLanguageDescriptions(
 
 ProtoModel *R2Architecture::protoModelFromR2CC(const char *cc) {
 	auto it = cc_map.find (cc);
-	if (it == cc_map.end ()) {
+	if (it != cc_map.end ()) {
+		for (const auto &name : it->second) {
+			auto protoIt = protoModels.find (name);
+			if (protoIt != protoModels.end ()) {
+				return protoIt->second;
+			}
+		}
+	}
+	auto cached = r2CCModels.find (cc);
+	if (cached != r2CCModels.end ()) {
+		return cached->second;
+	}
+	ProtoModel *model = nullptr;
+	{
+		RCoreLock core (getCore ());
+		const char *defcc = r_anal_cc_default (core->anal);
+		if (defcc && !strcmp (defcc, cc)) {
+			// the arch default cc is what the cspec default model describes, which is richer than the cc sdb
+			model = defaultfp;
+		}
+	}
+	if (!model) {
+		try {
+			model = buildProtoModelFromR2CC (cc);
+		} catch (const LowlevelError &e) {
+			addWarning ("Building a prototype model for calling convention " + std::string (cc) + " failed: " + e.explain);
+		} catch (const DecoderError &e) {
+			addWarning ("Building a prototype model for calling convention " + std::string (cc) + " failed: " + e.explain);
+		}
+	}
+	r2CCModels[cc] = model;
+	return model;
+}
+
+ProtoModel *R2Architecture::buildProtoModelFromR2CC(const char *cc) {
+	RCoreLock core (getCore ());
+	RAnal *anal = core->anal;
+	if (!translate || !r_anal_cc_exist (anal, cc)) {
 		return nullptr;
 	}
-	auto protoIt = protoModels.find (it->second);
-	if (protoIt == protoModels.end ()) {
+	int maxargs = r_anal_cc_max_arg (anal, cc);
+	const char *ret = r_anal_cc_ret (anal, cc, 0);
+	if (!ret) {
+		// a model without an output entry can throw ParamUnassignedError mid-decompile
 		return nullptr;
 	}
-	return protoIt->second;
+	int4 extrapop = defaultfp? defaultfp->getExtraPop (): 0;
+
+	Document doc;
+	doc.setName ("prototype");
+	doc.addAttribute ("name", std::string ("r2:") + cc);
+	doc.addAttribute ("extrapop", extrapop == ProtoModel::extrapop_unknown? "unknown": std::to_string (extrapop));
+
+	auto input = child (&doc, "input");
+	bool stackargs = false;
+	std::vector<const VarnodeData *> gprargs, fltargs;
+	for (int n = 0; n < maxargs && !stackargs; n++) {
+		const char *loc = r_anal_cc_argloc (anal, cc, n, 0, 0);
+		if (!loc || !strcmp (loc, "_")) {
+			continue;
+		}
+		// {grouped} multi-register args are represented by their first register
+		loc = r_anal_cc_location_first (anal, loc);
+		if (!loc) {
+			return nullptr;
+		}
+		if (*loc == '^') {
+			stackargs = true;
+			break;
+		}
+		const VarnodeData *vn = registerVarnodeFromR2Reg (loc);
+		if (!vn) {
+			return nullptr; // a model missing an arg slot would misnumber all later args
+		}
+		(isFloatReg (anal, loc)? fltargs: gprargs).push_back (vn);
+	}
+	// each storage class must form one contiguous pentry section; float goes first like the cspecs do
+	for (const VarnodeData *vn : fltargs) {
+		childPentry (input, vn, true);
+	}
+	for (const VarnodeData *vn : gprargs) {
+		childPentry (input, vn, false);
+	}
+	const char *argn = r_anal_cc_argloc (anal, cc, maxargs, 0, 0);
+	if (!stackargs && argn && argn[0] == '^' && argn[1] != '-') {
+		stackargs = true;
+	}
+	if (stackargs) {
+		// the cc sdb has no arg-save-area info, so stack args start right past any return address
+		ut64 base = extrapop == ProtoModel::extrapop_unknown? 0: (ut64)extrapop;
+		auto pentry = child (input, "pentry", {
+			{ "minsize", "1" },
+			{ "maxsize", "500" },
+			{ "align", std::to_string (translate->getDefaultSize ()) }
+		});
+		child (pentry, "addr", { { "space", "stack" }, { "offset", hex (base) } });
+	}
+	auto output = child (&doc, "output");
+	const char *rloc = r_anal_cc_location_first (anal, ret);
+	const VarnodeData *retvn = rloc && *rloc != '^'? registerVarnodeFromR2Reg (rloc): nullptr;
+	if (!retvn) {
+		return nullptr;
+	}
+	childPentry (output, retvn, isFloatReg (anal, rloc));
+
+	std::vector<std::pair<const VarnodeData *, bool>> effects;
+	bool anyclobber = false;
+	static const int regtypes[] = {
+		R_REG_TYPE_GPR, R_REG_TYPE_FPU, R_REG_TYPE_VEC64,
+		R_REG_TYPE_VEC128, R_REG_TYPE_VEC256, R_REG_TYPE_VEC512
+	};
+	for (int type : regtypes) {
+		if (!anal->reg->regset[type].regs) {
+			continue;
+		}
+		r_list_foreach_cpp<RRegItem>(anal->reg->regset[type].regs, [&](RRegItem *item) {
+			const VarnodeData *vn = registerVarnodeFromR2Reg (item->name);
+			if (!vn) {
+				return;
+			}
+			for (const auto &e : effects) {
+				if (e.first->space == vn->space && e.first->offset == vn->offset && e.first->size == vn->size) {
+					return;
+				}
+			}
+			bool clob = r_anal_cc_isclobber (anal, cc, item->name);
+			anyclobber |= clob;
+			effects.emplace_back (vn, clob);
+		});
+	}
+	if (anyclobber) {
+		// the sdb clobber/preserve sets are complements, so non-clobbered regs are unaffected
+		auto killed = child (&doc, "killedbycall");
+		auto unaffected = child (&doc, "unaffected");
+		for (const auto &e : effects) {
+			bool contained = false;
+			for (const auto &o : effects) {
+				if (&o != &e && o.first->space == e.first->space && o.first->size > e.first->size
+						&& o.first->offset <= e.first->offset
+						&& o.first->offset + o.first->size >= e.first->offset + e.first->size) {
+					contained = true;
+					break;
+				}
+			}
+			if (contained) {
+				continue; // subregisters ride with their container
+			}
+			child (e.second? killed: unaffected, "range", {
+				{ "space", e.first->space->getName () },
+				{ "first", hex (e.first->offset) },
+				{ "last", hex (e.first->offset + e.first->size - 1) }
+			});
+		}
+	}
+
+	XmlDecode dec (this, &doc);
+	return decodeProto (dec);
 }
 
 void R2Architecture::loadRegisters(const Translate *translate) {
@@ -86,16 +268,21 @@ void R2Architecture::loadRegisters(const Translate *translate) {
 	}
 }
 
-Address R2Architecture::registerAddressFromR2Reg(const char *regname) {
-	loadRegisters (translate);
+const VarnodeData *R2Architecture::registerVarnodeFromR2Reg(const char *regname) {
+	if (registers.empty ()) {
+		// rebuilding here would invalidate every VarnodeData pointer handed out before
+		loadRegisters (translate);
+	}
 	auto it = registers.find (regname);
 	if (it == registers.end ()) {
 		it = registers.find (tolower (regname));
 	}
-	if (it == registers.end ()) {
-		return Address (); // not found, invalid addr
-	}
-	return it->second.getAddr ();
+	return it == registers.end ()? nullptr: &it->second;
+}
+
+Address R2Architecture::registerAddressFromR2Reg(const char *regname) {
+	const VarnodeData *vn = registerVarnodeFromR2Reg (regname);
+	return vn? vn->getAddr (): Address (); // invalid addr if not found
 }
 
 std::string R2Architecture::registerNameFromAddress(const Address &addr, int4 size) {

--- a/src/R2Architecture.h
+++ b/src/R2Architecture.h
@@ -20,11 +20,14 @@ private:
 
 	R2TypeFactory *r2TypeFactory_ = nullptr;
 	std::map<std::string, VarnodeData> registers;
+	std::map<std::string, ProtoModel *> r2CCModels;
 	std::vector<std::string> warnings;
 
 	bool rawptr = false;
 
 	void loadRegisters(const Translate *translate);
+	const VarnodeData *registerVarnodeFromR2Reg(const char *regname);
+	ProtoModel *buildProtoModelFromR2CC(const char *cc);
 
 public:
 	explicit R2Architecture(RCore *core, const std::string &sleigh_id);

--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -30,22 +30,6 @@ Scope *R2Scope::buildSubScope(uint8 id, const string &nm) {
 	return new ScopeInternal(id, nm, arch);
 }
 
-static std::string hex(ut64 v) {
-	std::stringstream ss;
-	ss << "0x" << std::hex << v;
-	return ss.str ();
-}
-
-static Element *child(Element *el, const std::string &name, const std::map<std::string, std::string> &attrs = {}) {
-	auto child = new Element (el);
-	child->setName (name);
-	el->addChild (child);
-	for (const auto &attr : attrs) {
-		child->addAttribute (attr.first, attr.second);
-	}
-	return child;
-}
-
 static Element *childAddr(Element *el, const std::string &name, const Address &addr) {
 	return child(el, name, {
 		{ "space", addr.getSpace()->getName () },

--- a/src/R2Utils.h
+++ b/src/R2Utils.h
@@ -28,4 +28,20 @@ static inline std::string tolower(std::string str) {
 	return str;
 }
 
+static inline std::string hex(ut64 v) {
+	std::stringstream ss;
+	ss << "0x" << std::hex << v;
+	return ss.str ();
+}
+
+static inline ghidra::Element *child(ghidra::Element *el, const std::string &name, const std::map<std::string, std::string> &attrs = {}) {
+	auto c = new ghidra::Element (el);
+	c->setName (name);
+	el->addChild (c);
+	for (const auto &attr : attrs) {
+		c->addAttribute (attr.first, attr.second);
+	}
+	return c;
+}
+
 #endif

--- a/test/db/extras/ghidra_arch
+++ b/test/db/extras/ghidra_arch
@@ -110,16 +110,14 @@ x86:LE:16:Real Mode:
 
 //WARNING: Variable defined which should be unmapped: var_8h
 //WARNING: Variable defined which should be unmapped: var_4h
-//WARNING: Unknown calling convention -- yet parameter storage is locked
 
-uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
+uint fcn.00001c98(ushort noname_0,ushort noname_1,int16_t arg_ah,int16_t noname_3,int16_t arg_eh)
 
 {
     int16_t *piVar1;
     ushort unaff_CS;
     ushort unaff_DS;
-    ushort in_stack_00000004;
-    int16_t in_stack_00000008;
+    uint uVar2;
     int16_t in_stack_0000000c;
     int16_t var_8h;
     int16_t var_6h;
@@ -130,7 +128,7 @@ uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
     var_6h = 0x13da;
     do {
         func_0x0000ec24(unaff_CS,var_6h,unaff_DS,0x401e);
-        func_0x0000ec24(0xdee,in_stack_00000004,arg_ah,0x401e);
+        func_0x0000ec24(0xdee,noname_1,arg_ah,0x401e);
         func_0x0000e59a(0xdee,0x401e);
         var_2h = 0;
         do {
@@ -139,7 +137,7 @@ uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
                 cStack_4 = '\n';
             }
             if (var_2h < in_stack_0000000c) {
-                *(in_stack_00000008 + var_2h) = cStack_4;
+                *(noname_3 + var_2h) = cStack_4;
                 var_2h = var_2h + 1;
             }
         } while (cStack_4 != '\n');
@@ -155,9 +153,9 @@ uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
         unaff_CS = 0xdee;
         func_0x0000e59a(0xdee,0x401e);
         var_6h = 0x13db;
-    } while (*(in_stack_00000008 + var_2h + -1) != '\n');
-    *(in_stack_00000008 + var_2h + -1) = 0;
-    return _in_stack_00000008;
+    } while (*(noname_3 + var_2h + -1) != '\n');
+    *(noname_3 + var_2h + -1) = 0;
+    return uVar2;
 }
 
 EOF

--- a/test/db/extras/r2ghidra_arch
+++ b/test/db/extras/r2ghidra_arch
@@ -110,16 +110,14 @@ x86:LE:16:Real Mode:
 
 //WARNING: Variable defined which should be unmapped: var_8h
 //WARNING: Variable defined which should be unmapped: var_4h
-//WARNING: Unknown calling convention -- yet parameter storage is locked
 
-uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
+uint fcn.00001c98(ushort noname_0,ushort noname_1,int16_t arg_ah,int16_t noname_3,int16_t arg_eh)
 
 {
     int16_t *piVar1;
     ushort unaff_CS;
     ushort unaff_DS;
-    ushort in_stack_00000004;
-    int16_t in_stack_00000008;
+    uint uVar2;
     int16_t in_stack_0000000c;
     int16_t var_8h;
     int16_t var_6h;
@@ -130,7 +128,7 @@ uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
     var_6h = 0x13da;
     do {
         func_0x0000ec24(unaff_CS,var_6h,unaff_DS,0x401e);
-        func_0x0000ec24(0xdee,in_stack_00000004,arg_ah,0x401e);
+        func_0x0000ec24(0xdee,noname_1,arg_ah,0x401e);
         func_0x0000e59a(0xdee,0x401e);
         var_2h = 0;
         do {
@@ -139,7 +137,7 @@ uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
                 cStack_4 = '\n';
             }
             if (var_2h < in_stack_0000000c) {
-                *(in_stack_00000008 + var_2h) = cStack_4;
+                *(noname_3 + var_2h) = cStack_4;
                 var_2h = var_2h + 1;
             }
         } while (cStack_4 != '\n');
@@ -155,9 +153,9 @@ uint fcn.00001c98(int16_t arg_eh,int16_t arg_ah)
         unaff_CS = 0xdee;
         func_0x0000e59a(0xdee,0x401e);
         var_6h = 0x13db;
-    } while (*(in_stack_00000008 + var_2h + -1) != '\n');
-    *(in_stack_00000008 + var_2h + -1) = 0;
-    return _in_stack_00000008;
+    } while (*(noname_3 + var_2h + -1) != '\n');
+    *(noname_3 + var_2h + -1) = 0;
+    return uVar2;
 }
 
 EOF
@@ -496,3 +494,29 @@ EXPECT=<<EOF2
 EOF2
 RUN
 
+
+NAME=windows calling convention on a sysv binary resolves the MSABI proto model
+FILE=bins/elf/hello_world
+CMDS=<<EOF2
+s main
+af
+afc ms
+pdg~MSABI
+EOF2
+EXPECT=<<EOF2
+void MSABI main(int argc,char **argv,char **envp)
+EOF2
+RUN
+
+NAME=custom calling convention builds a prototype model from r2 cc data
+FILE=bins/elf/hello_world
+CMDS=<<EOF2
+s main
+af
+afc swift
+pdg~r2:swift
+EOF2
+EXPECT=<<EOF2
+void r2:swift main(int argc,char **argv,char **envp)
+EOF2
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Function calling conventions with no usable decompiler proto model previously fell back to nothing: a "Matching calling convention failed" warning and degraded argument recovery (every mips/riscv/s390x function, and any custom cc set via afc).

protoModelFromR2CC now resolves in three steps:

1. cc_map name lookup against the models the loaded cspec actually defines (entries are now tried in order: "ms" falls back to MSABI on the x86-64 gcc cspec, which has no __fastcall).
2. If the cc is r2's default calling convention for the arch, use the cspec's default proto model — the native model is always richer than what the cc sdb can express (float sections, model rules, stack save areas).
3. Otherwise lazily build an "r2:<cc>" model from r2's cc sdb (arglocs, ret, clobber/preserve as killedbycall/unaffected) and register it through Architecture::decodeProto. Serves custom conventions: swift, dyncc signatures, user-set afc, ms on a SysV binary.

Output is byte-identical on x86-64/arm64/arm32/ppc64 with default conventions. The x86_16 goldens change for the better: stack args are recovered as real parameters instead of raw in_stack_ reads, and the bogus stack-arg return becomes the proper DX:AX return. New tests pin the MSABI fallback and the r2-built model path.

Also fixes registerAddressFromR2Reg rebuilding the register map on every lookup, and a refcount leak on r_reg_get items.