### PR TITLE
Encode join-space pieces in R2Scope addresses

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -31,10 +31,35 @@ Scope *R2Scope::buildSubScope(uint8 id, const string &nm) {
 }
 
 static Element *childAddr(Element *el, const std::string &name, const Address &addr) {
-	return child(el, name, {
-		{ "space", addr.getSpace()->getName () },
-		{ "offset", hex(addr.getOffset ()) }
+	AddrSpace *space = addr.getSpace ();
+	if (space->getType () != IPTR_JOIN) {
+		return child (el, name, {
+			{ "space", space->getName () },
+			{ "offset", hex (addr.getOffset ()) }
+		});
+	}
+
+	// Join addresses must be marshaled with their physical pieces.
+	JoinRecord *record = space->getManager ()->findJoin (addr.getOffset ());
+	const int4 numPieces = record->numPieces ();
+	constexpr int4 maxMarshaledJoinPieces = 64; // JoinSpace::MAX_PIECES is private.
+	if (numPieces > maxMarshaledJoinPieces) {
+		throw LowlevelError ("Exceeded maximum pieces in one join address");
+	}
+
+	Element *result = child (el, name, {
+		{ "space", space->getName () }
 	});
+	for (int4 i = 0; i < numPieces; i++) {
+		const VarnodeData &piece = record->getPiece (i);
+		const std::string value = piece.space->getName () + ":" +
+			hex (piece.offset) + ":" + std::to_string (piece.size);
+		result->addAttribute ("piece" + std::to_string (i + 1), value);
+	}
+	if (numPieces == 1) {
+		result->addAttribute ("logicalsize", std::to_string (record->getUnified ().size));
+	}
+	return result;
 }
 
 static Element *childType(Element *el, Datatype *type) {

--- a/test/bins/Makefile
+++ b/test/bins/Makefile
@@ -29,3 +29,11 @@ elf/arm-stackchk: arm-stackchk.c
 elf/arm64-tailcall-local: arm64-tailcall-local.c
 	aarch64-linux-gnu-gcc -O2 -fPIC -nostdlib -nostartfiles -shared -fno-stack-protector \
 		-o elf/arm64-tailcall-local.so arm64-tailcall-local.c
+
+elf/join-hfa-arm64.o: join-hfa-arm64.c
+	aarch64-linux-gnu-gcc -O2 -c \
+		-fno-stack-protector \
+		-fno-asynchronous-unwind-tables \
+		-fno-unwind-tables \
+		-fno-ident \
+		-o elf/join-hfa-arm64.o join-hfa-arm64.c

--- a/test/bins/join-hfa-arm64.c
+++ b/test/bins/join-hfa-arm64.c
@@ -1,0 +1,12 @@
+struct V2 {
+	float x;
+	float y;
+};
+
+float sum2(struct V2 v) {
+	return v.x + v.y;
+}
+
+float scale1(float a) {
+	return a + a;
+}

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1933,3 +1933,30 @@ INFO: pdgw: wrote 0 types, 0 names, signature
 INFO: pdgw: no changes
 EOF
 RUN
+
+NAME=typed HFA parameter decodes join-space storage under pdg
+FILE=bins/elf/join-hfa-arm64.o
+CMDS=<<EOF
+s sym.sum2
+af
+'td struct V2 { float x; float y; };
+'afs float sum2(V2 v)
+pdg~v.x
+EOF
+EXPECT=<<EOF
+    return v.x + v.y;
+EOF
+RUN
+
+NAME=scalar float parameter keeps regular storage under pdg
+FILE=bins/elf/join-hfa-arm64.o
+CMDS=<<EOF
+s sym.scale1
+af
+'afs float scale1(float a)
+pdg~return
+EOF
+EXPECT=<<EOF
+    return a + a;
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: N/A
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Ghidra can use the join address space when one parameter is split across multiple physical locations.

This happens on AArch64 with homogeneous floating-point aggregates. For example, a structure containing two floats can be passed in two separate SIMD/FP registers.

R2Scope was serializing join addresses using only the space and offset. This is not enough because Ghidra needs the indexed `pieceN` attributes to rebuild the join address.

Before this patch, the HFA test failed with:

```text
Ghidra Decompiler Error: Cannot create a join without pieces
```

This patch updates `childAddr()` to serialize the physical pieces from the registered `JoinRecord`. Normal addresses keep the existing space and offset format.

The HFA regression now decompiles as:

```c
return v.x + v.y;
```

A scalar-float control test decompiles as:

```c
return a + a;
```

The HFA test verifies the join-address path. The scalar test verifies that normal non-join addresses are unchanged.

Expected results:

```text
Current upstream:
  HFA parameter:   Cannot create a join without pieces
  Scalar control: return a + a;

With this patch:
  HFA parameter:   return v.x + v.y;
  Scalar control: return a + a;
```

The test fixture is a small AArch64 relocatable object containing only the two functions required by these tests.