### PR TITLE
Preserve function pointer fields in imported structs

### DIFF
--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -419,6 +419,13 @@ Datatype *R2TypeFactory::queryR2Struct(const string &n, std::set<std::string> &s
 				arch->addWarning ("Failed to match type " + memberTypeName + " of member " + memberName + " in struct " + n);
 				continue;
 			}
+			if (memberType->getMetatype () == TYPE_CODE) {
+				auto space = arch->getDefaultCodeSpace ();
+				memberType = getTypePointer (
+					space->getAddrSize (),
+					memberType,
+					space->getWordSize ());
+			}
 			if (elements > 0) {
 				memberType = getTypeArray (elements, memberType);
 			}

--- a/test/bins/Makefile
+++ b/test/bins/Makefile
@@ -37,3 +37,12 @@ elf/join-hfa-arm64.o: join-hfa-arm64.c
 		-fno-unwind-tables \
 		-fno-ident \
 		-o elf/join-hfa-arm64.o join-hfa-arm64.c
+
+elf/function-pointer-field-arm64.o: function-pointer-field-arm64.c
+	aarch64-linux-gnu-gcc -O2 -c \
+		-fno-stack-protector \
+		-fno-asynchronous-unwind-tables \
+		-fno-unwind-tables \
+		-fno-ident \
+		-o elf/function-pointer-field-arm64.o \
+		function-pointer-field-arm64.c

--- a/test/bins/function-pointer-field-arm64.c
+++ b/test/bins/function-pointer-field-arm64.c
@@ -1,0 +1,23 @@
+struct Receiver;
+struct MethodInfo;
+
+struct ShortSlot {
+    float (*methodPtr)(struct Receiver *, const struct MethodInfo *);
+    const struct MethodInfo *method;
+};
+
+struct VeryLongConcreteGenericOwnerName_VTableSlot {
+    float (*methodPtr)(struct Receiver *, const struct MethodInfo *);
+    const struct MethodInfo *method;
+};
+
+float call_short_slot(struct ShortSlot *slot, struct Receiver *receiver)
+{
+    return slot->methodPtr(receiver, slot->method);
+}
+
+float call_long_slot(struct VeryLongConcreteGenericOwnerName_VTableSlot *slot,
+                     struct Receiver *receiver)
+{
+    return slot->methodPtr(receiver, slot->method);
+}

--- a/test/bins/function-pointer-field-arm64.h
+++ b/test/bins/function-pointer-field-arm64.h
@@ -1,0 +1,12 @@
+struct Receiver;
+struct MethodInfo;
+
+struct ShortSlot {
+    float (*methodPtr)(struct Receiver *receiver, const struct MethodInfo *method);
+    const struct MethodInfo *method;
+};
+
+struct VeryLongConcreteGenericOwnerName_VTableSlot {
+    float (*methodPtr)(struct Receiver *receiver, const struct MethodInfo *method);
+    const struct MethodInfo *method;
+};

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1960,3 +1960,31 @@ EXPECT=<<EOF
     return a + a;
 EOF
 RUN
+
+NAME=typed function pointer struct field is stored as a pointer
+FILE=bins/elf/function-pointer-field-arm64.o
+CMDS=<<EOF
+to bins/function-pointer-field-arm64.h
+s sym.call_short_slot
+af
+'afs float call_short_slot(ShortSlot* slot, Receiver* receiver)
+pdg~methodPtr
+EOF
+EXPECT=<<EOF
+    fVar1 = (*slot->methodPtr)(receiver,slot->method);
+EOF
+RUN
+
+NAME=typed function pointer field preserves return type with a long owner name
+FILE=bins/elf/function-pointer-field-arm64.o
+CMDS=<<EOF
+to bins/function-pointer-field-arm64.h
+s sym.call_long_slot
+af
+'afs float call_long_slot(VeryLongConcreteGenericOwnerName_VTableSlot* slot, Receiver* receiver)
+pdg~methodPtr
+EOF
+EXPECT=<<EOF
+    fVar1 = (*slot->methodPtr)(receiver,slot->method);
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: N/A
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

`to` stores a function-pointer struct member as a function type in the radare2 type database.

When `R2TypeFactory::queryR2Struct()` imports the member, `fromCString()` returns a `TYPE_CODE`. This type was inserted directly into the struct, even though a function cannot be stored inline as a struct field.

For example:

```c
struct ShortSlot {
	float (*methodPtr)(Receiver *receiver, int method);
	int method;
};
```

`methodPtr` occupies a pointer-sized field, so it must be represented as a pointer to the function type.

This patch converts `TYPE_CODE` struct members with `getTypePointer()` before applying a possible array declarator. This also keeps arrays of function pointers represented correctly.

Other member types are unchanged.

## Before

The function type was inserted directly into the struct.

The decompiler still recovered an indirect call, but it treated the function as if it was stored directly at the beginning of the struct:

```c
fVar1 = (**slot)(receiver,slot->method);
```

The call did not use the `methodPtr` field name, so the focused tests using:

```r2
pdg~methodPtr
```

returned no matching output.

## After

The member is imported as a pointer to the function type.

The decompiler now recovers the named struct field:

```c
fVar1 = (*slot->methodPtr)(receiver,slot->method);
```


## Tests

Two AArch64 tests were added.

The first uses a short struct name and checks the normal function-pointer field import.

The second uses a long owner type name and checks that the generated function type keeps its `float` return type.

Both tests fail on current upstream and pass with this patch.