### PR TITLE
Add ppc64 ELFv1 join storage regression tests for pdg

### DIFF
--- a/test/db/extras/r2ghidra_ppc64
+++ b/test/db/extras/r2ghidra_ppc64
@@ -1,0 +1,26 @@
+NAME=by-value struct parameter decodes ppc64 elfv1 join storage under pdg
+FILE=bins/elf/ppc64v1-vararg
+CMDS=<<EOF
+aa
+'td struct Pair { long a; long b; };
+s sym.caller
+'afs long caller(Pair p)
+pdg~vfmt
+EOF
+EXPECT=<<EOF
+    lVar1 = sym.vfmt(0x100001c8,p.a,p.b);
+EOF
+RUN
+
+NAME=scalar parameters keep regular register storage under pdg
+FILE=bins/elf/ppc64v1-vararg
+CMDS=<<EOF
+aa
+s sym.caller
+'afs long caller(long a, long b)
+pdg~vfmt
+EOF
+EXPECT=<<EOF
+    lVar1 = sym.vfmt(0x100001c8,a,b);
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

9db59e6 made join-space parameter storage decodable, tested only via arm64 HFAs. The same marshaling is what makes by-value struct parameters work on ppc64 ELFv1 (a 16-byte struct arrives as an r3:r4 join), so this adds a ppc64 regression pair: a typelocked by-value struct param rendering both halves as fields, and a scalar-args control. Fails on pre-9db59e6 builds with "Cannot create a join without pieces". New file db/extras/r2ghidra_ppc64 so arch-specific tests don't pile into r2ghidra_types.