### PR TITLE
Preserve function pointer members in imported unions

### DIFF
--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -340,6 +340,15 @@ static Datatype *make_typedef(R2TypeFactory *factory, Datatype *base, const std:
 	return typedefd;
 }
 
+// sdb member parsing yields the bare function type for fn-ptrs; re-wrap TYPE_CODE as a pointer
+static Datatype *code_to_pointer(R2TypeFactory *factory, Datatype *t) {
+	if (t->getMetatype () != TYPE_CODE) {
+		return t;
+	}
+	AddrSpace *space = factory->getArch ()->getDefaultCodeSpace ();
+	return factory->getTypePointer (space->getAddrSize (), t, space->getWordSize ());
+}
+
 static std::string make_tmp_typename(const std::string &type_str) {
 	ut32 hash = r_str_hash(type_str.c_str());
 	std::stringstream ss;
@@ -419,13 +428,7 @@ Datatype *R2TypeFactory::queryR2Struct(const string &n, std::set<std::string> &s
 				arch->addWarning ("Failed to match type " + memberTypeName + " of member " + memberName + " in struct " + n);
 				continue;
 			}
-			if (memberType->getMetatype () == TYPE_CODE) {
-				auto space = arch->getDefaultCodeSpace ();
-				memberType = getTypePointer (
-					space->getAddrSize (),
-					memberType,
-					space->getWordSize ());
-			}
+			memberType = code_to_pointer (this, memberType);
 			if (elements > 0) {
 				memberType = getTypeArray (elements, memberType);
 			}
@@ -546,6 +549,7 @@ Datatype *R2TypeFactory::queryR2Union(const string &n, std::set<std::string> &st
 				arch->addWarning ("Failed to match type " + memberTypeName + " of member " + memberName + " in union " + n);
 				continue;
 			}
+			memberType = code_to_pointer (this, memberType);
 			if (elements > 0) {
 				memberType = getTypeArray (elements, memberType);
 			}

--- a/test/bins/function-pointer-union-arm64.h
+++ b/test/bins/function-pointer-union-arm64.h
@@ -1,0 +1,12 @@
+struct Receiver;
+struct MethodInfo;
+
+union CallbackSlot {
+    float (*fn)(struct Receiver *receiver, const struct MethodInfo *method);
+    void *raw;
+};
+
+struct UnionSlot {
+    union CallbackSlot cb;
+    const struct MethodInfo *method;
+};

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1988,3 +1988,17 @@ EXPECT=<<EOF
     fVar1 = (*slot->methodPtr)(receiver,slot->method);
 EOF
 RUN
+
+NAME=typed function pointer union member is stored as a pointer
+FILE=bins/elf/function-pointer-field-arm64.o
+CMDS=<<EOF
+to bins/function-pointer-union-arm64.h
+s sym.call_short_slot
+af
+'afs float call_short_slot(UnionSlot* slot, Receiver* receiver)
+pdg~cb
+EOF
+EXPECT=<<EOF
+    fVar1 = (*(slot->cb).fn)(receiver,slot->method);
+EOF
+RUN

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1989,7 +1989,9 @@ EXPECT=<<EOF
 EOF
 RUN
 
+# radare2 stores union member metadata in sdb only after the 6.1.8 release
 NAME=typed function pointer union member is stored as a pointer
+BROKEN=1
 FILE=bins/elf/function-pointer-field-arm64.o
 CMDS=<<EOF
 to bins/function-pointer-union-arm64.h


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

862c7f6 wrapped TYPE_CODE struct members as pointers, but the identical member loop in queryR2Union was left out, so union function-pointer members still imported as bare function types (wrong size, no callable prototype):

    fVar1 = (*slot->cb)(receiver,slot->method);   // before
    fVar1 = (*(slot->cb).fn)(receiver,slot->method);  // after

The wrap is now a shared helper used by both the struct and union paths. The new test reuses bins/elf/function-pointer-field-arm64.o with a union-typed header, so it needs #284 to land first.