### PR TITLE
Rebuild the sleigh translator on language switch and fix vector register types

### DIFF
--- a/src/SleighAsm.cpp
+++ b/src/SleighAsm.cpp
@@ -29,24 +29,28 @@ void SleighAsm::init(const char *cpu, int bits, bool bigendian, RIO *io, RConfig
 	initInner (io, new_sleigh_id);
 }
 
-void SleighAsm::initInner(RIO *io, std::string sleigh_id) {
+void SleighAsm::initInner(RIO *io, const std::string &id) {
 	/* Initialize Sleigh */
+	// drop the old translator before its loader and context are replaced, a throw below must not leave a half-built one reachable
+	trans.reset ();
+	sleigh_id.clear ();
 	loader = std::move (AsmLoadImage (io));
 	docstorage = std::move (DocumentStorage ());
-	resolveArch (sleigh_id);
+	resolveArch (id);
 	buildSpecfile (docstorage);
 	context = std::move(ContextInternal ());
-	trans.reset (&loader, &context);
-	trans.initialize (docstorage);
+	// sleigh only loads the .sla while the translator is uninitialized, so a language switch needs a new one
+	trans = std::make_unique<R2Sleigh> (&loader, &context);
+	trans->initialize (docstorage);
 	parseProcConfig (docstorage);
 	parseCompConfig (docstorage);
-	alignment = trans.getAlignment ();
+	alignment = trans->getAlignment ();
 	RCore *core = (RCore *)io->coreb.core;
-	minopsz = ai (core, sleigh_id, R_ARCH_INFO_MINOP_SIZE);
-	maxopsz = ai (core, sleigh_id, R_ARCH_INFO_MAXOP_SIZE);
-	trans.clearCache ();
+	minopsz = ai (core, id, R_ARCH_INFO_MINOP_SIZE);
+	maxopsz = ai (core, id, R_ARCH_INFO_MAXOP_SIZE);
+	trans->clearCache ();
 	initRegMapping ();
-	this->sleigh_id = sleigh_id;
+	sleigh_id = id;
 	current_io = io;
 }
 
@@ -165,7 +169,7 @@ void SleighAsm::parseProcConfig(DocumentStorage &store) {
 	if (el == nullptr) {
 		throw LowlevelError ("No processor configuration tag found");
 	}
-	XmlDecode decoder (&trans, el);
+	XmlDecode decoder (trans.get (), el);
 	uint4 elemId = decoder.openElement (ELEM_PROCESSOR_SPEC);
 	for (;;) {
 		uint4 subId = decoder.peekElement();
@@ -462,10 +466,10 @@ std::string SleighAsm::getSleighHome(RConfig * R_NULLABLE cfg) {
 
 int SleighAsm::disassemble(RAnalOp *op, unsigned long long offset) {
 	AssemblySlg assem (this);
-	Address addr(trans.getDefaultCodeSpace (), offset);
+	Address addr(trans->getDefaultCodeSpace (), offset);
 	int length = 0;
 	try {
-		length = trans.printAssembly (assem, addr);
+		length = trans->printAssembly (assem, addr);
 		char *d = strdup (assem.str);
 		r_str_case (d, false);
 		free (op->mnemonic);
@@ -487,7 +491,7 @@ int SleighAsm::disassemble(RAnalOp *op, unsigned long long offset) {
 int SleighAsm::genOpcode(PcodeSlg &pcode_slg, Address &addr) {
 	int length = 0;
 	try {
-		length = trans.oneInstruction(pcode_slg, addr);
+		length = trans->oneInstruction(pcode_slg, addr);
 	} catch (BadDataError &err) {
 		/* Meet unknown data -> invalid opcode */
 		length = -1;
@@ -502,7 +506,7 @@ void SleighAsm::initRegMapping(void) {
 	reg_mapping.clear();
 	std::map<VarnodeData, std::string> reglist;
 	std::set<std::string> S;
-	trans.getAllRegisters(reglist);
+	trans->getAllRegisters(reglist);
 
 	for (auto iter = reglist.cbegin(); iter != reglist.cend (); iter++) {
 		std::string tmp;
@@ -520,7 +524,7 @@ void SleighAsm::initRegMapping(void) {
 std::vector<R2Reg> SleighAsm::getRegs(void) {
 	std::map<VarnodeData, std::string> reglist;
 	std::vector<R2Reg> r2_reglist;
-	trans.getAllRegisters(reglist);
+	trans->getAllRegisters(reglist);
 
 	if (reglist.empty()) {
 		return r2_reglist;
@@ -630,7 +634,7 @@ PcodeOperand *PcodeSlg::parse_vardata(VarnodeData &data) {
 }
 
 void SleighAsm::check(ut64 offset, const ut8 *buf, int len) { // To refresh cache when file content is modified.
-	ParserContext *ctx = trans.getContext (Address(trans.getDefaultCodeSpace(), offset), ParserContext::uninitialized);
+	ParserContext *ctx = trans->getContext (Address(trans->getDefaultCodeSpace(), offset), ParserContext::uninitialized);
 	if (ctx->getParserState () > ParserContext::uninitialized) {
 		ut8 *cached = ctx->getBuffer ();
 		size_t i = 0;

--- a/src/SleighAsm.h
+++ b/src/SleighAsm.h
@@ -10,6 +10,7 @@
 
 #include <r_core.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -204,8 +205,6 @@ struct R2Reg {
 	ut64 offset;
 };
 
-class R2Sleigh;
-
 class SleighAsm {
 private:
 	AsmLoadImage loader;
@@ -216,7 +215,7 @@ private:
 	std::vector<LanguageDescription> description;
 	int languageindex;
 
-	void initInner(RIO *io, std::string sleigh_id);
+	void initInner(RIO *io, const std::string &id);
 	void initRegMapping(void);
 	void collectSpecfiles(void);
 	void scanSleigh(const string &rootpath);
@@ -228,7 +227,7 @@ private:
 
 public:
 	static std::string getSleighHome(RConfig *cfg);
-	R2Sleigh trans;
+	std::unique_ptr<R2Sleigh> trans;
 	std::string sleigh_id;
 	int alignment = 1;
 	int minopsz = 1;
@@ -240,7 +239,7 @@ public:
 	std::unordered_map<std::string, std::string> reg_group;
 	// To satisfy radare2's rule: reg name has to be lowercase.
 	std::unordered_map<std::string, std::string> reg_mapping;
-	SleighAsm(): loader(nullptr), trans(nullptr, nullptr) {}
+	SleighAsm(): loader(nullptr) {}
 	void init(const char *cpu, int bits, bool bigendian, RIO *io, RConfig *cfg);
 	int disassemble(RAnalOp *op, unsigned long long offset);
 	int genOpcode(PcodeSlg &pcode_slg, Address &addr);

--- a/src/SleighInstruction.cpp
+++ b/src/SleighInstruction.cpp
@@ -19,11 +19,6 @@ SleighInstructionPrototype *R2Sleigh::getPrototype(SleighInstruction *context) {
 	return new_proto;
 }
 
-void R2Sleigh::reset(LoadImage *ld,ContextDatabase *c_db) {
-	R2loader = ld;
-	Sleigh::reset(ld, c_db);
-}
-
 SleighInstruction *R2Sleigh::getInstruction(Address &addr) {
 	SleighInstruction *inst = nullptr;
 #if 1

--- a/src/SleighInstruction.h
+++ b/src/SleighInstruction.h
@@ -285,7 +285,6 @@ public:
 	R2Sleigh(LoadImage *ld, ContextDatabase *c_db): R2loader(ld), Sleigh(ld, c_db) {}
 	~R2Sleigh() { clearCache(); }
 	
-	void reset(LoadImage *ld,ContextDatabase *c_db);
 	void reconstructContext(ParserContext &protoContext);
 	SleighParserContext *newSleighParserContext(Address &addr, SleighInstructionPrototype *proto);
 	SleighParserContext *getParserContext(Address &addr, SleighInstructionPrototype *proto);

--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -643,7 +643,7 @@ static void anal_type(RAnal *anal, RAnalOp *anal_op, PcodeSlg &pcode_slg, Assemb
 	std::vector<std::string> args = string_split(assem.str);
 	std::unordered_set<std::string> reg_set;
 	std::map<VarnodeData, std::string> reglist;
-	sanal->trans.getAllRegisters(reglist);
+	sanal->trans->getAllRegisters(reglist);
 	for (auto iter = args.cbegin(); iter != args.cend(); iter++) {
 		for (auto p = reglist.cbegin (); p != reglist.cend(); p++) {
 			if (sanal->reg_mapping[p->second] == *iter) {
@@ -1345,11 +1345,11 @@ extern "C" int sleigh_op(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data,
 		R_FREE (arch);
 
 		AssemblySlg assem(sanal);
-		Address at(sanal->trans.getDefaultCodeSpace(), addr);
+		Address at(sanal->trans->getDefaultCodeSpace(), addr);
 
 		if (1) { // mask & R_ANAL_OP_MASK_DISASM) {
 			try {
-				int size = sanal->trans.printAssembly (assem, at);
+				int size = sanal->trans->printAssembly (assem, at);
 				anal_op->size = size;
 				anal_op->mnemonic = strdup (assem.str);
 				r_str_case (anal_op->mnemonic, false);
@@ -1373,7 +1373,7 @@ extern "C" int sleigh_op(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data,
 		} catch (LowlevelError &err) {
 			// ignored
 		}
-		if ((anal_op->size < 1) || (sanal->trans.printAssembly(assem, at) < 1)) {
+		if ((anal_op->size < 1) || (sanal->trans->printAssembly(assem, at) < 1)) {
 			return anal_op->size; // When current place has no available code, return ILL.
 		}
 		if (pcode_slg.pcodes.empty()) { // NOP case
@@ -1382,7 +1382,7 @@ extern "C" int sleigh_op(RAnal *a, RAnalOp *anal_op, ut64 addr, const ut8 *data,
 			return anal_op->size;
 		}
 
-		SleighInstruction *ins = sanal->trans.getInstruction(at);
+		SleighInstruction *ins = sanal->trans->getInstruction(at);
 		if (ins == nullptr) {
 			return -1;
 		}
@@ -1749,7 +1749,7 @@ static void append_hardcoded_regs(std::stringstream &buf, const std::string &arc
 	}
 }
 
-static std::string regtype_name(const char *cpu, const std::string &regname) {
+static const char *regtype_name(const char *cpu, const std::string &regname, ut64 bits) {
 	if (r_str_startswith (cpu, "x86")) {
 		if (regname.find ("cr") != -1) {
 			return "drx";
@@ -1767,7 +1767,13 @@ static std::string regtype_name(const char *cpu, const std::string &regname) {
 			return "drx";
 		}
 		if (regname.find ("mm") != -1) {
-			return "mmx";
+			// r2 has no "mmx" type, and the narrower views must share one arena to alias
+			switch (bits) {
+			case 512: return "vec512";
+			case 256: return "vec256@vec512";
+			case 128: return "vec128@vec512";
+			default: return "vec64@vec512";
+			}
 		}
 	}
 	return "gpr";
@@ -1796,36 +1802,36 @@ extern "C" char *r2ghidra_regs(RArchSession *as) {
 	for (auto p = reg_list.begin(); p != reg_list.end(); p++) {
 		const std::string &group = sanal->reg_group[p->name];
 		const std::string &regname = sanal->reg_mapping[p->name];
-		const std::string &regtype = regtype_name (cpu, regname);
+		const ut64 bits = p->size * 8;
 		if (group.empty()) {
-			buf << regtype << "\t" << regname << "\t." << p->size * 8 << "\t"
-				    << p->offset << "\t" << "0\n";
-				continue;
-			}
-			for (size_t i = 0;; i++) {
-				if (!r_reg_type_arr[i]) {
-					R_LOG_WARN ("Unexpected register group(%s) from SLEIGH, abort", group.c_str());
-					return nullptr;
-				}
+			buf << regtype_name (cpu, regname, bits) << '\t';
+		} else {
+			size_t i;
+			for (i = 0; r_reg_type_arr[i]; i++) {
 				if (group == r_reg_type_arr[i]) {
 					buf << r_reg_string_arr[i] << '\t';
 					break;
 				}
 			}
-			buf << sanal->reg_mapping[p->name] << "\t." << p->size * 8 << "\t" << p->offset << "\t" << "0\n";
+			if (!r_reg_type_arr[i]) {
+				R_LOG_WARN ("Unexpected register group(%s) from SLEIGH, abort", group.c_str());
+				return nullptr;
+			}
 		}
-		if (!sanal->pc_name.empty()) {
-			buf << "=PC\t" << sanal->reg_mapping[sanal->pc_name] << '\n';
-		}
-		if (!sanal->sp_name.empty()) {
-			buf << "=SP\t" << sanal->reg_mapping[sanal->sp_name] << '\n';
-		}
-		for (unsigned i = 0; i != sanal->arg_names.size() && i <= 9; i++) {
-			buf << "=A" << i << '\t' << sanal->reg_mapping[sanal->arg_names[i]] << '\n';
-		}
-		for (unsigned i = 0; i != sanal->ret_names.size() && i <= 3; i++) {
-			buf << "=R" << i << '\t' << sanal->reg_mapping[sanal->ret_names[i]] << '\n';
-		}
+		buf << regname << "\t." << bits << "\t" << p->offset << "\t" << "0\n";
+	}
+	if (!sanal->pc_name.empty()) {
+		buf << "=PC\t" << sanal->reg_mapping[sanal->pc_name] << '\n';
+	}
+	if (!sanal->sp_name.empty()) {
+		buf << "=SP\t" << sanal->reg_mapping[sanal->sp_name] << '\n';
+	}
+	for (unsigned i = 0; i != sanal->arg_names.size() && i <= 9; i++) {
+		buf << "=A" << i << '\t' << sanal->reg_mapping[sanal->arg_names[i]] << '\n';
+	}
+	for (unsigned i = 0; i != sanal->ret_names.size() && i <= 3; i++) {
+		buf << "=R" << i << '\t' << sanal->reg_mapping[sanal->ret_names[i]] << '\n';
+	}
 
 	ut64 pp = 0;
 	string arch = sanal->sleigh_id.substr(pp, sanal->sleigh_id.find (':', pp) - pp);

--- a/test/db/extras/anal_ghidra
+++ b/test/db/extras/anal_ghidra
@@ -169,9 +169,7 @@ ao | grep type
 EOF
 RUN
 
-# the SleighAsm/R2Sleigh arch-plugin init loses sleigh context variables on x86 hosts (ShowPAC); the pdg core path decodes the same sleigh fine
 NAME=AARCH64:LE:64:v8A:gcc
-BROKEN=1
 FILE=malloc://2048
 EXPECT=<<EOF
             0x00000000      298947f9       ldr x9, [x9, #0xf10]
@@ -252,9 +250,7 @@ family: cpu
 EOF
 RUN
 
-# the SleighAsm/R2Sleigh arch-plugin init loses sleigh context variables on x86 hosts (ShowPAC); the pdg core path decodes the same sleigh fine
 NAME=AARCH64 esil
-BROKEN=1
 FILE=malloc://2048
 CMDS=<<EOF
 e log.level=0

--- a/test/db/extras/r2ghidra_arch
+++ b/test/db/extras/r2ghidra_arch
@@ -522,3 +522,35 @@ EXPECT=<<EOF2
 void r2:swift main(int argc,char **argv,char **envp)
 EOF2
 RUN
+
+NAME=arch plugin decodes both languages after switching cpu
+FILE=malloc://64
+ARGS=-a r2ghidra -b 64
+CMDS=<<EOF2
+e asm.cpu=arm
+wx 298947f9
+ao 1~mnemonic
+e asm.bits=32
+e asm.cpu=x86
+wx 90
+ao 1~mnemonic
+EOF2
+EXPECT=<<EOF2
+mnemonic: ldr
+mnemonic: nop
+EOF2
+RUN
+
+NAME=arch plugin emits a valid x86 vector register profile
+FILE=bins/elf/crackme0x05
+ARGS=-a r2ghidra
+CMDS=<<EOF2
+ar xmm0=0xff
+ar xmm0
+ar xmm0_qa
+EOF2
+EXPECT=<<EOF2
+0x000000000000000000000000000000ff
+0x000000ff
+EOF2
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

The arch plugin could only ever decode the first language a session initialised: Sleigh::initialize() ingests the .sla only while !isInitialized(), and Sleigh::reset() does not clear root, so every later switch kept the old sleigh tables while applying the new .pspec — hence "Non-existent context variable: ShowPAC". Now a fresh R2Sleigh is built per switch. Separately, regtype_name() emitted the register type "mmx", removed from r2 in 5.8.0, and one bad line makes r2 reject the whole profile; it now emits width-mapped vecN pinned to a shared @vec512 arena so the overlapping xmm/ymm/zmm views alias.

Not host-specific — asm.cpu just defaults to the host arch, so the host only decides which language gets locked in. Verified by the mirror case on arm64: master cannot decode x86 at all, this branch gives nop/mov/mov.

The two AARCH64 anal_ghidra tests are un-marked; they already passed on arm64 and only failed on amd64, so CI is what validates them.