### PR TITLE
Make the pdgx/pdgd code printing goldens version-stable and un-mark them

### DIFF
--- a/test/db/extras/ghidra_output
+++ b/test/db/extras/ghidra_output
@@ -1,6 +1,5 @@
-# pdgx/pdgd dumps embed decompiler-internal ids that shift across radare2 versions; needs a version-stable filter
+# the pdgx/pdgd filters drop ids, symbols and types that shift across radare2 versions
 NAME=code printing
-BROKEN=1
 FILE=bins/elf/crackme0x05
 EXPECT=<<EOF
 
@@ -90,101 +89,73 @@ CCu base64:Jg== @ 0x804858a
         <range space="ram" first="0x8048540" last="0x804859b"/>
       </rangelist>
       <op code="1">
-        <seqnum space="ram" offset="0x8048566" uniq="0xf6"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048566" uniq="0x80"/>
         <void/>
       </op>
       <op code="1">
-        <seqnum space="ram" offset="0x8048572" uniq="0xf7"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048572" uniq="0x85"/>
         <void/>
       </op>
       <op code="66">
-        <seqnum space="ram" offset="0x8048577" uniq="0xf8"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048585" uniq="0x8f"/>
         <void/>
       </op>
       <op code="66">
-        <seqnum space="ram" offset="0x804858a" uniq="0xf9"/>
       </op>
       <op code="64">
-        <seqnum space="ram" offset="0x8048590" uniq="0xfa"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048590" uniq="0x96"/>
         <void/>
       </op>
       <op code="1">
-        <seqnum space="ram" offset="0x8048595" uniq="0x97"/>
       </op>
       <op code="10">
-        <seqnum space="ram" offset="0x804859b" uniq="0x9d"/>
         <void/>
       </op>
     </block>
   </ast>
   <highlist>
-    <high repref="0x1a3" class="constant">
     </high>
-    <high repref="0x1c1" class="constant">
     </high>
-    <high repref="0x316" class="constant">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x317" class="constant">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x30b" class="constant">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x312" class="constant" symref="0x4000010000000003" offset="0">
     </high>
-    <high repref="0x314" class="constant" symref="0x4000010000000003" offset="0">
     </high>
-    <high repref="0x176" class="other">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x190" class="other">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x30d" class="other" typelock="true">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x310" class="other" typelock="true">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x318" class="other">
     </high>
-    <high repref="0x1a2" class="other">
     </high>
-    <high repref="0x240" class="other" typelock="true">
       <type name="" size="4" metatype="ptr">
         <type name="" size="0" metatype="spacebase" space="stack">
         </type>
       </type>
     </high>
-    <high repref="0x1c2" class="param" symref="0x4000010000000000">
     </high>
-    <high repref="0x1c3" class="param" symref="0x4000010000000001">
       <type name="" size="4" metatype="ptr" core="true">
         <type name="" size="4" metatype="ptr" core="true">
         </type>
       </type>
     </high>
-    <high repref="0x1c4" class="param" symref="0x4000010000000002">
       <type name="" size="4" metatype="ptr" core="true">
         <type name="" size="4" metatype="ptr" core="true">
         </type>
@@ -200,7 +171,6 @@ CCu base64:Jg== @ 0x804858a
   <syntax></syntax>
   <break indent="0"/>
   <funcproto>
-    <return_type varref="0x1a2">
       <syntax></syntax>
       <syntax></syntax>
     </return_type>
@@ -209,14 +179,12 @@ CCu base64:Jg== @ 0x804858a
     <syntax></syntax>
     <syntax open="113">(</syntax>
     <syntax></syntax>
-    <vardecl symref="0x4000010000000000">
       <syntax> </syntax>
       <variable color="0x6">argc</variable>
     </vardecl>
     <syntax></syntax>
     <syntax>, </syntax>
     <syntax></syntax>
-    <vardecl symref="0x4000010000000001">
       <syntax> </syntax>
       <op>*</op>
       <syntax></syntax>
@@ -227,7 +195,6 @@ CCu base64:Jg== @ 0x804858a
     <syntax></syntax>
     <syntax>, </syntax>
     <syntax></syntax>
-    <vardecl symref="0x4000010000000002">
       <syntax> </syntax>
       <op>*</op>
       <syntax></syntax>
@@ -243,76 +210,55 @@ CCu base64:Jg== @ 0x804858a
   <break indent="0"/>
   <syntax>{</syntax>
   <break indent="4"/>
-  <vardecl symref="0x4000010000000003">
     <syntax> </syntax>
     <variable color="0x4">var_78h</variable>
   </vardecl>
   <syntax></syntax>
   <syntax>;</syntax>
   <break indent="4"/>
-  <block blockref="0">
     <syntax></syntax>
     <break indent="4"/>
-    <statement opref="0x80">
-      <funcname color="0x3" opref="0x80">sym.imp.printf</funcname>
       <syntax></syntax>
       <syntax open="130">(</syntax>
       <syntax></syntax>
-      <variable color="0x5" varref="0x316" opref="0xf6">&quot;IOLI Crackme Level 0x05\n&quot;</variable>
       <syntax></syntax>
       <syntax close="130">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x85">
-      <funcname color="0x3" opref="0x85">sym.imp.printf</funcname>
       <syntax></syntax>
       <syntax open="133">(</syntax>
       <syntax></syntax>
-      <variable color="0x5" varref="0x317" opref="0xf7">&quot;Password: &quot;</variable>
       <syntax></syntax>
       <syntax close="133">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x8f">
-      <funcname color="0x3" opref="0x8f">sym.imp.scanf</funcname>
       <syntax></syntax>
       <syntax open="136">(</syntax>
       <syntax></syntax>
-      <variable color="0x5" varref="0x30b" opref="0x8f">0x80486b2</variable>
       <syntax></syntax>
-      <op opref="0x8f">, </op>
       <syntax></syntax>
-      <op opref="0xf8">&amp;</op>
       <syntax></syntax>
-      <variable color="0x4" opref="0xf8">var_78h</variable>
       <syntax></syntax>
       <syntax close="136">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x96">
-      <funcname color="0x3" opref="0x96">sym.check</funcname>
       <syntax></syntax>
       <syntax open="141">(</syntax>
       <syntax></syntax>
-      <op opref="0xf9">&amp;</op>
       <syntax></syntax>
-      <variable color="0x4" opref="0xf9">var_78h</variable>
       <syntax></syntax>
       <syntax close="141">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x9d">
-      <op color="0x0" opref="0x9d">return</op>
       <syntax> </syntax>
-      <variable color="0x5" varref="0x1a3" opref="0x97">0</variable>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
@@ -324,7 +270,6 @@ CCu base64:Jg== @ 0x804858a
 </function></code></result>
 --
 <save_state loadersymbols="false">
-  <typegrp/>
   <db>
     <property_changepoint space="register" offset="0x1100" val="0x20000000"/>
     <property_changepoint space="register" offset="0x110a" val="0x0"/>
@@ -342,178 +287,22 @@ CCu base64:Jg== @ 0x804858a
     <property_changepoint space="register" offset="0x116a" val="0x0"/>
     <property_changepoint space="register" offset="0x1170" val="0x20000000"/>
     <property_changepoint space="register" offset="0x117a" val="0x0"/>
-      <rangelist/>
-      <symbollist>
-        <mapsym>
-            <addr space="ram" offset="0x8048540"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffff5f"/>
-                  <range space="stack" first="0xffffff68" last="0xfffffffb"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist>
-                      <range space="ram" first="0x804853f" last="0x804853f"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                        <type name="" size="4" metatype="ptr" core="true">
-                        </type>
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0x8"/>
-                    <rangelist>
-                      <range space="ram" first="0x804853f" last="0x804853f"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                        <type name="" size="4" metatype="ptr" core="true">
-                        </type>
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0xc"/>
-                    <rangelist>
-                      <range space="ram" first="0x804853f" last="0x804853f"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0xffffff84"/>
-                    <rangelist/>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="register" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x8048540"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <type name="" size="25" metatype="array" arraysize="25">
-            </type>
-          </symbol>
-          <addr space="ram" offset="0x804868e"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <type name="" size="11" metatype="array" arraysize="11">
-            </type>
-          </symbol>
-          <addr space="ram" offset="0x80486a7"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <addr space="ram" offset="0x80484c8"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffffff"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist/>
-                  </mapsym>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0xfffffff4"/>
-                    <rangelist/>
-                  </mapsym>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0xfffffff0"/>
-                    <rangelist/>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="stack" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x80484c8"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <addr space="ram" offset="0x8048394"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffffff"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist>
-                      <range space="ram" first="0x8048393" last="0x8048393"/>
-                    </rangelist>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="stack" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x8048394"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <addr space="ram" offset="0x8048374"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffffff"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0x8"/>
-                    <rangelist>
-                      <range space="ram" first="0x8048373" last="0x8048373"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist>
-                      <range space="ram" first="0x8048373" last="0x8048373"/>
-                    </rangelist>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="stack" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x8048374"/>
-          <rangelist/>
-        </mapsym>
-      </symbollist>
     </scope>
   </db>
   <context_points>
@@ -612,13 +401,11 @@ CCu base64:Jg== @ 0x804858a
   <commentdb/>
   <stringmanage>
     <string>
-      <addr space="ram" offset="0x804868e"/>
       <bytes trunc="false">
 494f4c4920437261636b6d65204c6576656c2030
   7830350a0050617373776f72
 </bytes>
       <string>
-        <addr space="ram" offset="0x80486a7"/>
         <bytes trunc="false">
 50617373776f72643a2000257300000000000000
   00ffffffffffffffffffffff
@@ -637,9 +424,9 @@ pdgo
 ?e --
 pdg*
 ?e --
-pdgx~!id=,<addr
+pdgx~!id=,ref=,uniq=,<addr
 ?e --
-pdgd~!id=,protectedMode
+pdgd~!id=,protectedMode,type,returnsym,<addr,range,mapsym,<symbol,</symbol
 ?e --
 # XXX: uncomment to test colors
 # e scr.color=3

--- a/test/db/extras/r2ghidra_output
+++ b/test/db/extras/r2ghidra_output
@@ -1,6 +1,5 @@
-# pdgx/pdgd dumps embed decompiler-internal ids that shift across radare2 versions; needs a version-stable filter
+# the pdgx/pdgd filters drop ids, symbols and types that shift across radare2 versions
 NAME=code printing
-BROKEN=1
 FILE=bins/elf/crackme0x05
 EXPECT=<<EOF
 
@@ -90,101 +89,73 @@ CCu base64:Jg== @ 0x804858a
         <range space="ram" first="0x8048540" last="0x804859b"/>
       </rangelist>
       <op code="1">
-        <seqnum space="ram" offset="0x8048566" uniq="0xf6"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048566" uniq="0x80"/>
         <void/>
       </op>
       <op code="1">
-        <seqnum space="ram" offset="0x8048572" uniq="0xf7"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048572" uniq="0x85"/>
         <void/>
       </op>
       <op code="66">
-        <seqnum space="ram" offset="0x8048577" uniq="0xf8"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048585" uniq="0x8f"/>
         <void/>
       </op>
       <op code="66">
-        <seqnum space="ram" offset="0x804858a" uniq="0xf9"/>
       </op>
       <op code="64">
-        <seqnum space="ram" offset="0x8048590" uniq="0xfa"/>
       </op>
       <op code="7">
-        <seqnum space="ram" offset="0x8048590" uniq="0x96"/>
         <void/>
       </op>
       <op code="1">
-        <seqnum space="ram" offset="0x8048595" uniq="0x97"/>
       </op>
       <op code="10">
-        <seqnum space="ram" offset="0x804859b" uniq="0x9d"/>
         <void/>
       </op>
     </block>
   </ast>
   <highlist>
-    <high repref="0x1a3" class="constant">
     </high>
-    <high repref="0x1c1" class="constant">
     </high>
-    <high repref="0x316" class="constant">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x317" class="constant">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x30b" class="constant">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x312" class="constant" symref="0x4000010000000003" offset="0">
     </high>
-    <high repref="0x314" class="constant" symref="0x4000010000000003" offset="0">
     </high>
-    <high repref="0x176" class="other">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x190" class="other">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x30d" class="other" typelock="true">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x310" class="other" typelock="true">
       <type name="" size="4" metatype="ptr" core="true">
       </type>
     </high>
-    <high repref="0x318" class="other">
     </high>
-    <high repref="0x1a2" class="other">
     </high>
-    <high repref="0x240" class="other" typelock="true">
       <type name="" size="4" metatype="ptr">
         <type name="" size="0" metatype="spacebase" space="stack">
         </type>
       </type>
     </high>
-    <high repref="0x1c2" class="param" symref="0x4000010000000000">
     </high>
-    <high repref="0x1c3" class="param" symref="0x4000010000000001">
       <type name="" size="4" metatype="ptr" core="true">
         <type name="" size="4" metatype="ptr" core="true">
         </type>
       </type>
     </high>
-    <high repref="0x1c4" class="param" symref="0x4000010000000002">
       <type name="" size="4" metatype="ptr" core="true">
         <type name="" size="4" metatype="ptr" core="true">
         </type>
@@ -200,7 +171,6 @@ CCu base64:Jg== @ 0x804858a
   <syntax></syntax>
   <break indent="0"/>
   <funcproto>
-    <return_type varref="0x1a2">
       <syntax></syntax>
       <syntax></syntax>
     </return_type>
@@ -209,14 +179,12 @@ CCu base64:Jg== @ 0x804858a
     <syntax></syntax>
     <syntax open="113">(</syntax>
     <syntax></syntax>
-    <vardecl symref="0x4000010000000000">
       <syntax> </syntax>
       <variable color="0x6">argc</variable>
     </vardecl>
     <syntax></syntax>
     <syntax>, </syntax>
     <syntax></syntax>
-    <vardecl symref="0x4000010000000001">
       <syntax> </syntax>
       <op>*</op>
       <syntax></syntax>
@@ -227,7 +195,6 @@ CCu base64:Jg== @ 0x804858a
     <syntax></syntax>
     <syntax>, </syntax>
     <syntax></syntax>
-    <vardecl symref="0x4000010000000002">
       <syntax> </syntax>
       <op>*</op>
       <syntax></syntax>
@@ -243,76 +210,55 @@ CCu base64:Jg== @ 0x804858a
   <break indent="0"/>
   <syntax>{</syntax>
   <break indent="4"/>
-  <vardecl symref="0x4000010000000003">
     <syntax> </syntax>
     <variable color="0x4">var_78h</variable>
   </vardecl>
   <syntax></syntax>
   <syntax>;</syntax>
   <break indent="4"/>
-  <block blockref="0">
     <syntax></syntax>
     <break indent="4"/>
-    <statement opref="0x80">
-      <funcname color="0x3" opref="0x80">sym.imp.printf</funcname>
       <syntax></syntax>
       <syntax open="130">(</syntax>
       <syntax></syntax>
-      <variable color="0x5" varref="0x316" opref="0xf6">&quot;IOLI Crackme Level 0x05\n&quot;</variable>
       <syntax></syntax>
       <syntax close="130">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x85">
-      <funcname color="0x3" opref="0x85">sym.imp.printf</funcname>
       <syntax></syntax>
       <syntax open="133">(</syntax>
       <syntax></syntax>
-      <variable color="0x5" varref="0x317" opref="0xf7">&quot;Password: &quot;</variable>
       <syntax></syntax>
       <syntax close="133">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x8f">
-      <funcname color="0x3" opref="0x8f">sym.imp.scanf</funcname>
       <syntax></syntax>
       <syntax open="136">(</syntax>
       <syntax></syntax>
-      <variable color="0x5" varref="0x30b" opref="0x8f">0x80486b2</variable>
       <syntax></syntax>
-      <op opref="0x8f">, </op>
       <syntax></syntax>
-      <op opref="0xf8">&amp;</op>
       <syntax></syntax>
-      <variable color="0x4" opref="0xf8">var_78h</variable>
       <syntax></syntax>
       <syntax close="136">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x96">
-      <funcname color="0x3" opref="0x96">sym.check</funcname>
       <syntax></syntax>
       <syntax open="141">(</syntax>
       <syntax></syntax>
-      <op opref="0xf9">&amp;</op>
       <syntax></syntax>
-      <variable color="0x4" opref="0xf9">var_78h</variable>
       <syntax></syntax>
       <syntax close="141">)</syntax>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
     <break indent="4"/>
-    <statement opref="0x9d">
-      <op color="0x0" opref="0x9d">return</op>
       <syntax> </syntax>
-      <variable color="0x5" varref="0x1a3" opref="0x97">0</variable>
     </statement>
     <syntax></syntax>
     <syntax>;</syntax>
@@ -324,7 +270,6 @@ CCu base64:Jg== @ 0x804858a
 </function></code></result>
 --
 <save_state loadersymbols="false">
-  <typegrp/>
   <db>
     <property_changepoint space="register" offset="0x1100" val="0x20000000"/>
     <property_changepoint space="register" offset="0x110a" val="0x0"/>
@@ -342,178 +287,22 @@ CCu base64:Jg== @ 0x804858a
     <property_changepoint space="register" offset="0x116a" val="0x0"/>
     <property_changepoint space="register" offset="0x1170" val="0x20000000"/>
     <property_changepoint space="register" offset="0x117a" val="0x0"/>
-      <rangelist/>
-      <symbollist>
-        <mapsym>
-            <addr space="ram" offset="0x8048540"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffff5f"/>
-                  <range space="stack" first="0xffffff68" last="0xfffffffb"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist>
-                      <range space="ram" first="0x804853f" last="0x804853f"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                        <type name="" size="4" metatype="ptr" core="true">
-                        </type>
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0x8"/>
-                    <rangelist>
-                      <range space="ram" first="0x804853f" last="0x804853f"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                        <type name="" size="4" metatype="ptr" core="true">
-                        </type>
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0xc"/>
-                    <rangelist>
-                      <range space="ram" first="0x804853f" last="0x804853f"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0xffffff84"/>
-                    <rangelist/>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="register" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x8048540"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <type name="" size="25" metatype="array" arraysize="25">
-            </type>
-          </symbol>
-          <addr space="ram" offset="0x804868e"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <type name="" size="11" metatype="array" arraysize="11">
-            </type>
-          </symbol>
-          <addr space="ram" offset="0x80486a7"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <addr space="ram" offset="0x80484c8"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffffff"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist/>
-                  </mapsym>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0xfffffff4"/>
-                    <rangelist/>
-                  </mapsym>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0xfffffff0"/>
-                    <rangelist/>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="stack" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x80484c8"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <addr space="ram" offset="0x8048394"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffffff"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist>
-                      <range space="ram" first="0x8048393" last="0x8048393"/>
-                    </rangelist>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="stack" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x8048394"/>
-          <rangelist/>
-        </mapsym>
-        <mapsym>
-            <addr space="ram" offset="0x8048374"/>
             <localdb main="stack" lock="false">
-                <rangelist>
-                  <range space="stack" first="0x4" last="0x1f7"/>
-                  <range space="stack" first="0xfff0bdc0" last="0xffffffff"/>
-                </rangelist>
-                <symbollist>
-                  <mapsym>
-                    </symbol>
-                    <addr space="stack" offset="0x8"/>
-                    <rangelist>
-                      <range space="ram" first="0x8048373" last="0x8048373"/>
-                    </rangelist>
-                  </mapsym>
-                  <mapsym>
-                      <type name="" size="4" metatype="ptr" core="true">
-                      </type>
-                    </symbol>
-                    <addr space="stack" offset="0x4"/>
-                    <rangelist>
-                      <range space="ram" first="0x8048373" last="0x8048373"/>
-                    </rangelist>
-                  </mapsym>
-                </symbollist>
               </scope>
             </localdb>
-            <prototype model="__cdecl" extrapop="4" modellock="true">
-              <returnsym>
-                <addr space="stack" offset="0x0" size="4"/>
-              </returnsym>
-            </prototype>
           </function>
-          <addr space="ram" offset="0x8048374"/>
-          <rangelist/>
-        </mapsym>
-      </symbollist>
     </scope>
   </db>
   <context_points>
@@ -612,13 +401,11 @@ CCu base64:Jg== @ 0x804858a
   <commentdb/>
   <stringmanage>
     <string>
-      <addr space="ram" offset="0x804868e"/>
       <bytes trunc="false">
 494f4c4920437261636b6d65204c6576656c2030
   7830350a0050617373776f72
 </bytes>
       <string>
-        <addr space="ram" offset="0x80486a7"/>
         <bytes trunc="false">
 50617373776f72643a2000257300000000000000
   00ffffffffffffffffffffff
@@ -636,9 +423,9 @@ pdgo
 ?e --
 pdg*
 ?e --
-pdgx~!id=,<addr
+pdgx~!id=,ref=,uniq=,<addr
 ?e --
-pdgd~!id=,protectedMode
+pdgd~!id=,protectedMode,type,returnsym,<addr,range,mapsym,<symbol,</symbol
 # ?e --
 # e scr.color=3 - XXX: Make colors work on tests
 # pdg


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

The two "code printing" tests had been red on master for a long time and were marked BROKEN, so they detected nothing — unnoticed because CI never ran db/extras until recently. Their pdgx/pdgd dumps embed decompiler-internal ids and per-symbol/prototype detail that shifts between r2 versions (the biggest offender being <prototype dotdotdot="true">, the variadic libc markers newer r2 ships).

The filters now drop those: ref= covers repref/varref/opref/symref/blockref, and type covers prototype. Both goldens are regenerated; pdg, pdgo and pdg* are byte-identical to before, so all user-visible output is asserted exactly as it was. Filtering the old golden with the new terms reproduces the new one byte-for-byte, which shows the filters neutralise the version drift.

db/extras: 105 OK / 0 BR / 0 XX, same under the installed plugin and a fresh build. Verified non-vacuous by breaking the symbol feed on purpose: the test still fails.