### PR TITLE
Recover call-site varargs for user-declared format functions

### DIFF
--- a/src/PcodeFixupPreprocessor.cpp
+++ b/src/PcodeFixupPreprocessor.cpp
@@ -278,14 +278,32 @@ void PcodeFixupPreprocessor::fixupResolvedIndirectCalls(RAnalFunction *r2Func, F
 		});
 }
 
-static bool is_printf_family(const char *name) {
+static bool name_in_csv(const char *csv, const char *name) {
+	if (R_STR_ISEMPTY (csv)) {
+		return false;
+	}
+	bool found = false;
+	RList *names = r_str_split_duplist (csv, ",", true);
+	if (!names) {
+		return false;
+	}
+	r_list_foreach_cpp<char> (names, [&](char *s) {
+		if (!strcmp (s, name)) {
+			found = true;
+		}
+	});
+	r_list_free (names);
+	return found;
+}
+
+static bool is_format_callee(RCore *core, const char *name) {
 	static const char *fam[] = { "printf", "fprintf", "sprintf", "snprintf", "dprintf" };
 	for (const char *f : fam) {
 		if (!strcmp (name, f)) {
 			return true;
 		}
 	}
-	return false;
+	return name_in_csv (r_config_get (core->config, "r2ghidra.varargs.formats"), name);
 }
 
 static std::string resolve_callee_name(RCore *core, ut64 target) {
@@ -543,7 +561,7 @@ static FuncProto *build_locked_proto(R2Architecture &arch, const char *cc, const
 static void override_format_call(RCore *core, R2Architecture &arch, Funcdata *ghFunc, Sdb *tdb,
 		const std::unordered_map<std::string, ut64> &reg_strings, RAnalOp *op, AddrSpace *space) {
 	const std::string callee = resolve_callee_name (core, op->jump);
-	if (callee.empty () || !is_printf_family (callee.c_str ())) {
+	if (callee.empty () || !is_format_callee (core, callee.c_str ())) {
 		return;
 	}
 	VariadicSig sig;
@@ -551,10 +569,12 @@ static void override_format_call(RCore *core, R2Architecture &arch, Funcdata *gh
 		return;
 	}
 	const char *cc = r_anal_cc_func (core->anal, callee.c_str ());
-	if (!cc) {
-		cc = r_anal_cc_default (core->anal);
-	}
 	const char *freg = r_anal_cc_argloc (core->anal, cc, sig.firstVararg - 1, 0, 0);
+	if (!freg && !r_anal_cc_exist (core->anal, cc)) {
+		// the C parsers stamp cc=cdecl on every td/to prototype, and cdecl is undefined outside x86-32
+		cc = r_anal_cc_default (core->anal);
+		freg = r_anal_cc_argloc (core->anal, cc, sig.firstVararg - 1, 0, 0);
+	}
 	auto it = freg? reg_strings.find (tolower (freg)): reg_strings.end ();
 	if (it == reg_strings.end ()) {
 		return;

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -83,6 +83,7 @@ CV cfg_var_verbose    ("verbose",     "false",    "Show verbose warning messages
 CV cfg_var_casts      ("casts",       "false",    "Show type casts where needed");
 CV cfg_var_fixups     ("fixups",      "false",    "Apply pcode fixups");
 CV cfg_var_varargs    ("varargs",     "false",    "Recover printf-family varargs from literal format strings");
+CV cfg_var_vaformats  ("varargs.formats", "",     "Extra printf-style formatters for vararg recovery (bare names, comma separated)");
 CV cfg_var_roprop     ("roprop",      "0",        "Propagate read-only constants (0,1,2,3,4)");
 CV cfg_var_timeout    ("timeout",     "0",        "Run decompilation in a separate process and kill it after a specific time");
 CV cfg_var_compiler   ("compiler",    "default",  "Select compiler for calling conventions", ConfigCompiler);

--- a/test/db/extras/r2ghidra_output
+++ b/test/db/extras/r2ghidra_output
@@ -1237,3 +1237,34 @@ EXPECT=<<EOF2
 EOF2
 RUN
 
+# fr renames the import flag only, so the callee resolves as mylog while pdg keeps printing the function name
+NAME=user-declared formatter recovers call-site varargs via r2ghidra.varargs.formats
+FILE=bins/elf/x86_64-varargs.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF2
+e r2ghidra.varargs=true
+e r2ghidra.varargs.formats=mylog
+aaa
+fr sym.imp.snprintf sym.imp.mylog
+td int mylog(char *dst, int n, const char *fmt, ...)
+pdg @ sym.p_snprintf~n=%d
+EOF2
+EXPECT=<<EOF2
+    iVar1 = sym.imp.snprintf(*0x1fd0,0x40,"n=%d x=%x",arg1,arg2);
+EOF2
+RUN
+
+NAME=a formatter absent from r2ghidra.varargs.formats is left to decompiler liveness
+FILE=bins/elf/x86_64-varargs.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF2
+e r2ghidra.varargs=true
+aaa
+fr sym.imp.snprintf sym.imp.mylog
+td int mylog(char *dst, int n, const char *fmt, ...)
+pdg @ sym.p_snprintf~n=%d
+EOF2
+EXPECT=<<EOF2
+    iVar1 = sym.imp.snprintf(*0x1fd0,0x40,"n=%d x=%x",arg1 & 0xffffffff,arg2 & 0xffffffff);
+EOF2
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

pdg's vararg recovery only recognised five hardcoded libc names, so it was a no-op on binaries using their own printf-style formatters. New config r2ghidra.varargs.formats takes a comma-separated list of extra names; the format argument is still found generically as the last fixed parameter. Default empty, so nothing changes unless configured.

The allowlist alone was not enough: td/to stamp cc=cdecl on every parsed prototype, and cdecl is undefined outside x86-32, so the format register lookup returned NULL and recovery bailed. When the declared convention is unknown to r2 the code now retries with the binary's default one.

Two tests: a renamed import driven through the config, and a negative control confirming an unlisted name is left to decompiler liveness.
