### PR TITLE
Exclude relocation targets from readonly constant propagation

### DIFF
--- a/src/R2LoadImage.cpp
+++ b/src/R2LoadImage.cpp
@@ -89,6 +89,23 @@ static void addRangesWithPointers(RCoreLock &core, RangeList &list, AddrSpace *s
 	});
 }
 
+// the loader fills relocation targets in at runtime, so their on-disk bytes are not constants
+static void removeRelocRanges(RCoreLock &core, RangeList &list, AddrSpace *space) {
+	RRBTree *relocs = r_bin_get_relocs (core->bin);
+	if (!relocs) {
+		return;
+	}
+	const ut64 width = (core->rasm->config->bits == 64)? 8: 4;
+	RRBNode *node;
+	RBinReloc *reloc;
+	r_crbtree_foreach (relocs, node, RBinReloc, reloc) {
+		const ut64 at = reloc->vaddr;
+		if (at && at != UT64_MAX) {
+			list.removeRange (space, at, at + width - 1);
+		}
+	}
+}
+
 void R2LoadImage::getReadonly(RangeList &list) const {
 	RCoreLock core(coreMutex);
 	int roprop = r_config_get_i (core->config, "r2ghidra.roprop");
@@ -125,5 +142,6 @@ void R2LoadImage::getReadonly(RangeList &list) const {
 			list.insertRange(space, 0, UT64_MAX - 1);
 			break;
 		}
+		removeRelocRanges (core, list, space);
 	}
 }

--- a/test/db/extras/r2ghidra_output
+++ b/test/db/extras/r2ghidra_output
@@ -1056,3 +1056,16 @@ EXPECT=<<EOF2
     iVar1 = sym.imp.snprintf(*0x1fd0,0x40,"n=%d x=%x",arg1 & 0xffffffff,arg2 & 0xffffffff);
 EOF2
 RUN
+
+NAME=readonly propagation does not fold relocation targets to their on-disk zero
+FILE=bins/elf/x86_64-varargs.so
+CMDS=<<EOF2
+e r2ghidra.roprop=3
+aaa
+s main
+pdg~gmon_start
+EOF2
+EXPECT=<<EOF2
+        (*_reloc.__gmon_start__)();
+EOF2
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

With r2ghidra.roprop on, Ghidra constant-folds loads from the ranges getReadonly() reports. Relocation targets read as 0 on disk because the loader fills them at runtime, so a guard like if (*got != 0) folds to false and the block is deleted behind nothing but a "Removing unreachable block" comment — a decompile that looks successful with the body silently gone.

Reproduces on a shipped testbin: bins/elf/x86_64-varargs.so entry0 at roprop=3 loses its __gmon_start__ call, since *0x1fd8 is a SET_64 relocation. Subtracting reloc targets from the range list makes that function match roprop=0 exactly. A regression test pins it and fails without the fix.

roprop stays default-off: it still drops bodies on some binaries even at roprop=1, which inserts no ranges at all, so at least one other readonly source remains to be found.