### PR TITLE
Unmark the extras tests fixed by the r2-6.2.0 pin

### DIFF
--- a/test/db/extras/r2ghidra_arch
+++ b/test/db/extras/r2ghidra_arch
@@ -287,9 +287,7 @@ pdg
 EOF
 RUN
 
-# needs the anal.gp auto-seeding added to radare2 after the 6.1.8 release
 NAME=mips gp-relative import argument resolves under pdg
-BROKEN=1
 FILE=bins/elf/boa-mips-mini
 CMDS=<<EOF
 0x00400500;af;pdg~sym.imp.umask,sym.imp.time

--- a/test/db/extras/r2ghidra_output
+++ b/test/db/extras/r2ghidra_output
@@ -912,9 +912,7 @@ x86:LE:64:default:clangwindows
 EOF2
 RUN
 
-# printf is variadic in radare2 sdb signatures only after the 6.1.8 release
 NAME=x86-64 printf call-site varargs recovered from the format string under pdg
-BROKEN=1
 FILE=bins/elf/x86_64-varargs.so
 ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF2
@@ -927,9 +925,7 @@ EXPECT=<<EOF2
 EOF2
 RUN
 
-# printf is variadic in radare2 sdb signatures only after the 6.1.8 release
 NAME=vararg recovery off leaves call-site args to decompiler liveness
-BROKEN=1
 FILE=bins/elf/x86_64-varargs.so
 ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF2
@@ -955,9 +951,7 @@ EXPECT=<<EOF2
 EOF2
 RUN
 
-# printf is variadic in radare2 sdb signatures only after the 6.1.8 release
 NAME=scanf-family is left untouched by printf vararg recovery
-BROKEN=1
 FILE=bins/elf/x86_64-varargs.so
 ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF2
@@ -970,9 +964,7 @@ EXPECT=<<EOF2
 EOF2
 RUN
 
-# printf is variadic in radare2 sdb signatures only after the 6.1.8 release
 NAME=arm64 printf call-site varargs recovered from the format string under pdg
-BROKEN=1
 FILE=bins/elf/arm64-varargs.so
 ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF2
@@ -998,9 +990,7 @@ EXPECT=<<EOF2
 EOF2
 RUN
 
-# printf is variadic in radare2 sdb signatures only after the 6.1.8 release
 NAME=ppc64 printf float vararg lands in an fp register under pdg
-BROKEN=1
 FILE=bins/elf/ppc64v1-printf-vararg
 ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF2

--- a/test/db/extras/r2ghidra_types
+++ b/test/db/extras/r2ghidra_types
@@ -1954,9 +1954,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-# radare2 stores union member metadata in sdb only after the 6.1.8 release
 NAME=typed function pointer union member is stored as a pointer
-BROKEN=1
 FILE=bins/elf/function-pointer-field-arm64.o
 CMDS=<<EOF
 to bins/function-pointer-union-arm64.h


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Seven tests were marked BROKEN because they needed radare2 features newer than 6.1.8: variadic printf sdb markers (5 in r2ghidra_output), union member metadata (r2ghidra_types), and anal.gp auto-seeding (r2ghidra_arch). All three ship in 6.2.0, which CI now pins, so the markers and their comments are stale.

db/extras is 118 OK / 0 BR / 0 XX / 0 SK / 0 FX, stable over three runs. No goldens touched.