### PR TITLE
Warn in the pdg header when relocations have not been applied

### DIFF
--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -211,6 +211,39 @@ static void seedGlobalPointerRegister(R2Architecture &arch, RCore *core, RAnalFu
 	});
 }
 
+// unrelocated branch bytes decode as self-calls, so the recovered flow is fiction
+static void warnOnUnappliedRelocs(RCore *core, RAnalFunction *function, Funcdata *func) {
+	RBinObject *bo = r_bin_cur_object (core->bin);
+	if (!bo || bo->is_reloc_patched) {
+		return;
+	}
+#if R2_ABIVERSION >= 136
+	RVecRBinReloc *relocs = r_bin_get_relocs (core->bin);
+#else
+	RRBTree *relocs = r_bin_get_relocs (core->bin);
+#endif
+	if (!relocs) {
+		return;
+	}
+	const ut64 lo = r_anal_function_min_addr (function);
+	const ut64 hi = r_anal_function_max_addr (function);
+	bool found = false;
+	RBinReloc *reloc;
+#if R2_ABIVERSION >= 136
+	R_VEC_FOREACH (relocs, reloc) {
+		found |= reloc->vaddr >= lo && reloc->vaddr < hi;
+	}
+#else
+	RRBNode *node;
+	r_crbtree_foreach (relocs, node, RBinReloc, reloc) {
+		found |= reloc->vaddr >= lo && reloc->vaddr < hi;
+	}
+#endif
+	if (found) {
+		func->warningHeader ("Relocations are not applied, use -e bin.relocs.apply=true");
+	}
+}
+
 static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstream &out_stream, RCodeMeta **out_code, Harvest *out_harvest = nullptr) {
 	RAnalFunction *function = r_anal_get_fcn_in (core->anal, addr, R_ANAL_FCN_TYPE_NULL);
 	if (!function) {
@@ -238,6 +271,7 @@ static void Decompile(RCore *core, ut64 addr, DecompileMode mode, std::stringstr
 	arch.getCore()->sleepBegin ();
 	auto action = arch.allacts.getCurrent ();
 
+	warnOnUnappliedRelocs (core, function, func);
 	if (cfg_var_fixups.GetBool (core->config)) {
 		PcodeFixupPreprocessor::fixupSharedReturnJumpToRelocs(function, func, core, arch);
 	}

--- a/test/db/extras/r2ghidra_arch
+++ b/test/db/extras/r2ghidra_arch
@@ -338,6 +338,28 @@ ulong sym..crc32_init(int64_t arg1)
 EOF
 RUN
 
+NAME=et_rel with unapplied relocs is flagged in the pdg warning header
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=<<EOF
+aa
+pdg @ sym..crc32_init~Relocations
+EOF
+EXPECT=<<EOF
+//WARNING: Relocations are not applied, use -e bin.relocs.apply=true
+EOF
+RUN
+
+NAME=et_rel with applied relocs is not flagged in the pdg warning header
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+aa
+pdg @ sym..crc32_init~Relocations
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
 NAME=ppc64 sign-prefixed register arg keeps its 64-bit width under pdg
 FILE=bins/elf/ppc64v1-crc32_generic.ko
 ARGS=-e bin.relocs.apply=true


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

On an unlinked object with `bin.relocs.apply` off, relocated branch bytes still decode as self-calls, so `pdg` silently reports fictional control flow — sometimes with Ghidra's "Possible PIC construction" warnings, sometimes with none at all when a `reloc.` flag sits on the call site and the callee looks like a known function.

Emits `//WARNING: Relocations are not applied, use -e bin.relocs.apply=true` when the current object has unapplied relocs inside the decompiled function's range. Two tests on the existing ppc64 ET_REL fixture, covering both the warned and applied cases.